### PR TITLE
Dependency freeze

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # LNLDB 
-[![Build Status](https://travis-ci.org/WPI-LNL/lnldb.svg)](https://travis-ci.org/WPI-LNL/lnldb) [![Coverage Status](https://coveralls.io/repos/WPI-LNL/lnldb/badge.svg?branch=master&service=github)](https://coveralls.io/github/WPI-LNL/lnldb?branch=master)
+[![Build Status](https://travis-ci.org/WPI-LNL/lnldb.svg)](https://travis-ci.org/WPI-LNL/lnldb) [![Coverage Status](https://coveralls.io/repos/WPI-LNL/lnldb/badge.svg?branch=master&service=github)](https://coveralls.io/github/WPI-LNL/lnldb?branch=master) [![Dependency Status](https://gemnasium.com/WPI-LNL/lnldb.svg)](https://gemnasium.com/WPI-LNL/lnldb)
+
 ## Intro
 LNLDB runs under Python2.x and Django.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,41 +1,38 @@
-#### TODO: put version numbers for these
-mechanize
-BeautifulSoup
+mechanize==0.2.5
+BeautifulSoup==3.2.1
 #### ^^^ Check if actually needed. Currently only in the unused scrapers.
 Django<1.9
-Markdown
-pillow
-pisa
-pytz
-django-lineage
-django-bootstrap-toolkit
+Markdown==2.6.2
+pillow==2.9.0
+pisa==3.0.33
+pytz==2015.4
+django-lineage==0.2.0
+django-bootstrap-toolkit==2.15.0
 -e git://github.com/WPI-lnl/django-cas2.git#egg=django_cas-dev
+# TODO: replace ^^^ with a real cas library
 # django-ajax-selects >= 1.3.7
 # replace it once ajax-selects releases 1.3.7
 -e git+https://github.com/crucialfelix/django-ajax-selects@34ef412#egg=django-ajax-selects
 -e git+https://github.com/jmerdich/django-bootstrap-calendar.git#egg=django_bootstrap_calendar
-# django-crispy-forms>= 1.4.1
-# replace it once d-c-f releases 1.4.1
--e git+https://github.com/maraujop/django-crispy-forms.git@dev#egg=django-crispy-forms
-django-uuidfield
+django-crispy-forms== 1.5.0
+django-uuidfield==0.5.0
 # TODO: migrate ^^^
-flup
-raven
+raven==5.5.0
 xhtml2pdf==0.0.6
-reportlab
-django-markdown-deux
-django-ical
-django-debug-toolbar
-django-watson
-django-formtools
-django-debug-toolbar-line-profiler
-django-debug-toolbar-template-profiler
-django-permission
-django-hijack
-django-multiupload
-django-extensions
-django-reversion
-django-pagedown
-docutils
-django-mptt
-django-natural-duration
+reportlab==3.2.0
+django-markdown-deux==1.0.5
+django-ical==1.3
+django-debug-toolbar==1.3.2
+django-watson==1.1.8
+django-formtools==1.0
+django-debug-toolbar-line-profiler==0.4.0
+django-debug-toolbar-template-profiler==1.0.1
+django-permission==0.8.8
+django-hijack==1.0.9
+django-multiupload==0.5
+django-extensions==1.5.5
+django-reversion==1.9.3
+django-pagedown==0.1.0
+docutils==0.12
+django-mptt==0.7.4
+django-natural-duration==0.1


### PR DESCRIPTION
The last dependency has stopped putting warnings for 1.8. Freezing for stability.
