### PR TITLE
Enable redirects (requires migrate)

### DIFF
--- a/lnldb/settings.py
+++ b/lnldb/settings.py
@@ -185,6 +185,7 @@ MIDDLEWARE_CLASSES = (
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
     # 'events.middleware.ContactReminderMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
+    'django.contrib.redirects.middleware.RedirectFallbackMiddleware',
 )
 
 ROOT_URLCONF = 'lnldb.urls'
@@ -197,6 +198,7 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',
+    'django.contrib.redirects',
     'django.contrib.messages',
     'django.contrib.staticfiles',
     # Uncomment the next line to enable the admin:


### PR DESCRIPTION
This enables the webmaster to make arbitrary redirects via the admin interface, instead of using the .htaccess file as we do now. 

### Pros:
 - Really easy to add/modify redirects
 - Can account for everything in one place
 - Will only affect 'missing' pages; impossible to break the site

### Cons:
 - First request is marginally slower

### Instructions after merge:

ssh into the ccc machine and then:
```
cd lnldb
git pull
python manage.py migrate
dbtouch
```