### PR TITLE
Update URL patterns to make more sense and future-proof

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,6 +1,10 @@
+from django.conf import settings
 from django.conf.urls import include, url
+from django.contrib.auth import views as auth_views
 
-from . import views
+import django_cas_ng.views
+
+from . import views, forms
 
 each_member_pattern = [
     url(r'^edit/$', views.UserUpdateView.as_view(), name="update"),
@@ -26,5 +30,48 @@ urlpatterns = [
 
     url(r'^db/members/(?P<pk>[0-9]+)/', include(each_member_pattern)),
     url(r'^db/members/(?P<username>[A-Za-z][A-Za-z0-9]*)/', include(each_member_pattern, namespace='by-name')),
+
+    # AUTH
+    # use the nice redirector for login
+    url(r'^login/$', views.smart_login, name="login"),
+
+    # best use CAS for logout, since it's guaranteed to log the user out
+    #  (without immediately signing them back in)
+    url(r'^logout/$', django_cas_ng.views.logout, name="logout"),
+
+    # now for logical separation of the two auth portals
+    url(r'^cas/', include([
+        url(r'^login/$', django_cas_ng.views.login, name="login"),
+        url(r'^logout/$', django_cas_ng.views.logout, name="logout"),
+    ], namespace="cas")),
+
+    url(r'^local/', include([
+        url(r'^login/$', auth_views.login,
+            {'template_name': 'registration/login.html',
+             'authentication_form': forms.LoginForm},
+            name="login"),
+
+        url(r'^local/logout/$', auth_views.logout,
+            {'template_name': 'registration/logout.html'},
+            name="logout"),
+    ], namespace="local")),
+
+    # and keep password resets separate from either (though technically local)
+    url(r'^local/reset/', include([
+        url(r'^$', auth_views.password_reset,
+            {'template_name': 'registration/reset_password.html',
+             'from_email': settings.DEFAULT_FROM_ADDR},
+            name='start'),
+        url(r'^confirm/(?P<uidb64>[0-9A-Za-z]+)-(?P<token>.+)/$',
+            auth_views.password_reset_confirm,
+            {'template_name': 'registration/reset_password_form.html'},
+            name='confirm'),
+        url(r'^sent/$', auth_views.password_reset_done,
+            {'template_name': 'registration/reset_password_sent.html'},
+            name='sent'),
+        url(r'^done/$', auth_views.password_reset_complete,
+            {'template_name': 'registration/reset_password_finished.html'},
+            name='done'),
+    ], namespace="reset")),
 
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -157,7 +157,7 @@ def smart_login(request):
     pref_cas = request.COOKIES.get('prefer_cas', None)
     use_cas = request.GET.get("force_cas", None)
 
-    next_url = request.GET.get("next", reverse('db'))
+    next_url = request.GET.get("next", reverse('home'))
     if request.user.is_authenticated():
         return HttpResponseRedirect(next_url)
     if pref_cas == "true" or use_cas == "true" or "ticket" in request.GET:

--- a/data/tests/util.py
+++ b/data/tests/util.py
@@ -1,0 +1,21 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+
+
+@override_settings(TEMPLATE_STRING_IF_INVALID='TEMPLATE_WARNING [%s]')
+class ViewTestCase(TestCase):
+    def setUp(self):
+        # I have the same password on my luggage!!!
+        self.credentials = {'username': 'testuser',
+                            'password': '12345'}
+        extra = {'email': 'abc@foo.com',
+                 'is_staff': True,
+                 'is_superuser': False}
+        extra.update(self.credentials)
+        self.user = get_user_model().objects._create_user(**extra)
+        self.user.save()
+
+        self.assertTrue(self.client.login(username='testuser', password='12345'))
+
+    def assertOk(self, response, status_code=200):
+        return self.assertNotContains(response, "TEMPLATE_WARNING", status_code)

--- a/data/views.py
+++ b/data/views.py
@@ -1,90 +1,14 @@
 import mimetypes
 import os
-import re
 import stat
 
-from django.conf import settings
-from django.contrib.auth.decorators import login_required, permission_required
-from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.core.urlresolvers import reverse
-from django.http import (FileResponse, HttpResponse, HttpResponseNotModified,
-                         HttpResponseRedirect)
+from django.contrib.auth.decorators import login_required
+from django.http import FileResponse, HttpResponseNotModified
 from django.shortcuts import render
 from django.utils.datastructures import MultiValueDictKeyError
 from django.utils.http import http_date, urlquote_plus
 from django.views.static import was_modified_since
 from watson import search as watson
-
-from data.models import StupidCat
-
-
-@login_required
-def fuckoffkitty(request):
-    if request.GET.__contains__('next'):
-        requested_uri = request.GET['next']
-        StupidCat.objects.create(
-            user=request.user,
-            user_ip=request.META['REMOTE_ADDR'],
-            requested_uri=requested_uri
-        )
-        return HttpResponseRedirect(reverse('data.views.fuckoffkitty'))
-    else:
-        context = {}
-        try:
-            kitty = StupidCat.objects.filter(user=request.user).latest()
-        except:
-            return HttpResponse("Error: Schrodinger's Cat")
-        context['kitty'] = kitty
-        context['foo'] = 'foo'
-
-        return render(request, 'kitty.html', context)
-
-
-@login_required
-def status(request):
-    context = {}
-    try:
-        # want to keep the git revision stuff on one page ONLY, so I'll stick it all here.
-        git_change_file = open(os.path.join(settings.SITE_ROOT, '.git', 'COMMIT_EDITMSG'))
-        context['CHANGELOG'] = "\n".join(git_change_file.readlines())
-        git_change_file.close()
-
-        git_hash_file = open(os.path.join(settings.SITE_ROOT, '.git', 'HEAD'))
-        git_hash_text = '\n'.join(git_hash_file.readlines())
-        git_hash_file.close()
-        while 'ref:' in git_hash_text:
-            follow_path = re.search('^ref: (.+)$', git_hash_text).group(1)
-            followed_file = open(os.path.join(settings.SITE_ROOT, '.git', follow_path))
-            git_hash_text = "\n".join(followed_file.readlines())
-            followed_file.close()
-        context['REVISION'] = git_hash_text[:6]
-    except:
-        pass
-
-    return render(request, 'status_page.html', context)
-
-
-@login_required
-@permission_required('events.event_view_granular', raise_exception=True)
-def access_log(request):
-    context = {}
-
-    entries = StupidCat.objects.all()
-    paginator = Paginator(entries, 50)
-
-    page = request.GET.get('page')
-
-    try:
-        accesses = paginator.page(page)
-    except PageNotAnInteger:
-        # If page is not an integer, deliver first page.
-        accesses = paginator.page(1)
-    except EmptyPage:
-        # If page is out of range (e.g. 9999), deliver last page of results.
-        accesses = paginator.page(paginator.num_pages)
-
-    context['accesses'] = accesses
-    return render(request, 'access_log.html', context)
 
 
 @login_required

--- a/emails/urls.py
+++ b/emails/urls.py
@@ -1,0 +1,10 @@
+from django.conf.urls import url
+
+from . import views
+
+urlpatterns = [
+    url(r'^announce/(?P<slug>[-0-9a-f]+)/$', views.MeetingAnnounceView.as_view(),
+        name="pre-meeting"),
+    url(r'^announcecc/(?P<slug>[-0-9a-f]+)/$', views.MeetingAnnounceCCView.as_view(),
+        name="post-meeting"),
+]

--- a/events/forms.py
+++ b/events/forms.py
@@ -476,7 +476,7 @@ class EventReviewForm(forms.ModelForm):
                 HTML('<h4> Does this look good to you?</h4>'),
                 Submit('save', 'Yes!', css_class='btn btn-lg btn-danger'),
                 HTML(
-                    '<a class="btn btn-lg btn-success" href="{%% url "events.views.flow.viewevent" %s %%}"> No... </a>'
+                    '<a class="btn btn-lg btn-success" href="{%% url "events:detail" %s %%}"> No... </a>'
                     % event.id),
             ),
         )

--- a/events/models.py
+++ b/events/models.py
@@ -497,7 +497,7 @@ class Event(models.Model):
         return self.org.first()
 
     def ccreport_url(self):
-        return reverse("my-ccreport", args=(self.id,))
+        return reverse("my:report", args=(self.id,))
 
     def usercanseeevent(self, user):
 

--- a/events/templatetags/at_event_linking.py
+++ b/events/templatetags/at_event_linking.py
@@ -28,7 +28,7 @@ def eventlink(value, targeturlname=None):
                     reverse(targeturlname, args=(event.id,)), event.event_name))
             else:
                 new_value = new_value.replace(m.group(), '<a href="%s">@%s</a> ' % (
-                    reverse("events-detail", args=(event.id,)), event.event_name))
+                    reverse("events:detail", args=(event.id,)), event.event_name))
         except Event.DoesNotExist:
             pass
     return new_value
@@ -51,7 +51,7 @@ def mdeventlink(value, targeturlname=None):
                     event.event_name, reverse(targeturlname, args=(event.id,))))
             else:
                 new_value = new_value.replace(m.group(), '[@%s](%s) ' % (
-                    event.event_name, reverse("events-detail", args=(event.id,))))
+                    event.event_name, reverse("events:detail", args=(event.id,))))
         except Event.DoesNotExist:
             pass
     return new_value

--- a/events/tests/test_event_view.py
+++ b/events/tests/test_event_view.py
@@ -35,7 +35,7 @@ class EventBasicViewTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
     def test_close(self):
-        response = self.client.post(reverse('event-close', args=[self.e.pk]))
+        response = self.client.post(reverse("events:close", args=[self.e.pk]))
         self.assertEqual(response.status_code, 302)
 
     def test_reopen(self):

--- a/events/tests/test_event_view.py
+++ b/events/tests/test_event_view.py
@@ -92,11 +92,11 @@ class EventBasicViewTest(TestCase):
         # later: test post saved
 
     def test_bill_add(self):
-        response = self.client.get(reverse('event-mkbilling', args=[self.e.pk]))
+        response = self.client.get(reverse("events:bills:new", args=[self.e.pk]))
         self.assertEqual(response.status_code, 200)
 
         # Bad input
-        response = self.client.post(reverse('event-mkbilling', args=[self.e.pk]))
+        response = self.client.post(reverse("events:bills:new", args=[self.e.pk]))
         self.assertEqual(response.status_code, 200)
 
         # later: test post

--- a/events/tests/test_event_view.py
+++ b/events/tests/test_event_view.py
@@ -31,7 +31,7 @@ class EventBasicViewTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
     def test_deny(self):
-        response = self.client.post(reverse('event-deny', args=[self.e.pk]))
+        response = self.client.post(reverse("events:deny", args=[self.e.pk]))
         self.assertEqual(response.status_code, 302)
 
     def test_close(self):

--- a/events/tests/test_event_view.py
+++ b/events/tests/test_event_view.py
@@ -44,11 +44,11 @@ class EventBasicViewTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
     def test_approve(self):
-        response = self.client.get(reverse('event-approve', args=[self.e.pk]))
+        response = self.client.get(reverse("events:approve", args=[self.e.pk]))
         self.assertEqual(response.status_code, 200)
 
         # Bad input
-        response = self.client.post(reverse('event-approve', args=[self.e.pk]))
+        response = self.client.post(reverse("events:approve", args=[self.e.pk]))
         self.assertEqual(response.status_code, 200)
 
         # later: test post

--- a/events/tests/test_event_view.py
+++ b/events/tests/test_event_view.py
@@ -82,11 +82,11 @@ class EventBasicViewTest(TestCase):
         # later: test post saved
 
     def test_myccr_add(self):
-        response = self.client.get(reverse('my-ccreport', args=[self.e.pk]))
+        response = self.client.get(reverse("my:report", args=[self.e.pk]))
         self.assertEqual(response.status_code, 200)
 
         # Bad (empty) input
-        response = self.client.post(reverse('my-ccreport', args=[self.e.pk]))
+        response = self.client.post(reverse("my:report", args=[self.e.pk]))
         self.assertEqual(response.status_code, 200)
 
         # later: test post saved

--- a/events/tests/test_event_view.py
+++ b/events/tests/test_event_view.py
@@ -62,21 +62,21 @@ class EventBasicViewTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
     def test_ccr_add(self):
-        response = self.client.get(reverse('event-mkccr', args=[self.e.pk]))
+        response = self.client.get(reverse("events:reports:new", args=[self.e.pk]))
         self.assertEqual(response.status_code, 200)
 
         # Empty (bad) input
-        response = self.client.post(reverse('event-mkccr', args=[self.e.pk]))
+        response = self.client.post(reverse("events:reports:new", args=[self.e.pk]))
         self.assertEqual(response.status_code, 200)
 
         # later: test post saved
 
     def test_ccr_edit(self):
-        response = self.client.get(reverse('event-updccr', args=[self.e.pk, self.report.pk]))
+        response = self.client.get(reverse("events:reports:edit", args=[self.e.pk, self.report.pk]))
         self.assertEqual(response.status_code, 200)
 
         # Empty (bad) input
-        response = self.client.post(reverse('event-updccr', args=[self.e.pk, self.report.pk]))
+        response = self.client.post(reverse("events:reports:edit", args=[self.e.pk, self.report.pk]))
         self.assertEqual(response.status_code, 200)
 
         # later: test post saved

--- a/events/tests/test_event_view.py
+++ b/events/tests/test_event_view.py
@@ -27,7 +27,7 @@ class EventBasicViewTest(TestCase):
         # later: test post
 
     def test_cancel(self):
-        response = self.client.post(reverse('event-cancel', args=[self.e.pk]))
+        response = self.client.post(reverse("events:cancel", args=[self.e.pk]))
         self.assertEqual(response.status_code, 302)
 
     def test_deny(self):

--- a/events/tests/test_event_view.py
+++ b/events/tests/test_event_view.py
@@ -109,6 +109,20 @@ class EventListBasicViewTest(TestCase):
         self.user = UserFactory.create(password='123')
         self.client.login(username=self.user.username, password='123')
 
+    def test_public(self):
+        response = self.client.get(reverse('cal:list'))
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(reverse('cal:api'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_cal(self):
+        response = self.client.get(reverse('cal:feed'))
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(reverse('cal:feed-full'))
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(reverse('cal:feed-light'))
+        self.assertEqual(response.status_code, 200)
+
     def test_incoming(self):
         response = self.client.get(reverse('events:incoming'))
         self.assertEqual(response.status_code, 200)

--- a/events/tests/test_event_view.py
+++ b/events/tests/test_event_view.py
@@ -40,7 +40,7 @@ class EventBasicViewTest(TestCase):
 
     def test_reopen(self):
         self.test_close()
-        response = self.client.post(reverse('event-reopen', args=[self.e.pk]))
+        response = self.client.post(reverse("events:reopen", args=[self.e.pk]))
         self.assertEqual(response.status_code, 302)
 
     def test_approve(self):

--- a/events/tests/test_event_view.py
+++ b/events/tests/test_event_view.py
@@ -54,11 +54,11 @@ class EventBasicViewTest(TestCase):
         # later: test post
 
     def test_review(self):
-        response = self.client.get(reverse('event-review', args=[self.e.pk]))
+        response = self.client.get(reverse("events:review", args=[self.e.pk]))
         self.assertEqual(response.status_code, 200)
 
         # Default input should be good
-        response = self.client.post(reverse('event-review', args=[self.e.pk]))
+        response = self.client.post(reverse("events:review", args=[self.e.pk]))
         self.assertEqual(response.status_code, 302)
 
     def test_ccr_add(self):

--- a/events/tests/test_event_view.py
+++ b/events/tests/test_event_view.py
@@ -17,11 +17,11 @@ class EventBasicViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_edit(self):
-        response = self.client.get(reverse('event-edit', args=[self.e.pk]))
+        response = self.client.get(reverse('events:edit', args=[self.e.pk]))
         self.assertEqual(response.status_code, 200)
 
         # Bad input
-        response = self.client.post(reverse('event-edit', args=[self.e.pk]))
+        response = self.client.post(reverse('events:edit', args=[self.e.pk]))
         self.assertEqual(response.status_code, 200)
 
         # later: test post

--- a/events/tests/test_event_view.py
+++ b/events/tests/test_event_view.py
@@ -13,7 +13,7 @@ class EventBasicViewTest(TestCase):
         self.client.login(username=self.user.username, password='123')
 
     def test_detail(self):
-        response = self.client.get(reverse('events-detail', args=[self.e.pk]))
+        response = self.client.get(reverse('events:detail', args=[self.e.pk]))
         self.assertEqual(response.status_code, 200)
 
     def test_edit(self):

--- a/events/tests/test_my.py
+++ b/events/tests/test_my.py
@@ -70,19 +70,19 @@ class MyViewTest(TestCase):
 
     def test_cc_report_blank(self):
         mommy.make(EventCCInstance, event=self.e, crew_chief=self.user)
-        response = self.client.get(reverse("my-ccreport", args=[self.e.pk]))
+        response = self.client.get(reverse("my:report", args=[self.e.pk]))
         self.assertEqual(response.status_code, 200)
 
     def test_cc_report_error_post(self):
         mommy.make(EventCCInstance, event=self.e, crew_chief=self.user)
-        response = self.client.post(reverse("my-ccreport", args=[self.e.pk]),)
+        response = self.client.post(reverse("my:report", args=[self.e.pk]),)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(list(self.e.ccreport_set.filter(crew_chief=self.user)), [])
 
     def test_cc_report_post(self):
         mommy.make(EventCCInstance, event=self.e, crew_chief=self.user)
         response = self.client.post(
-            reverse("my-ccreport", args=[self.e.pk]),
+            reverse("my:report", args=[self.e.pk]),
             data={
                 'report': "lorem ipsum something or another",
                 'crew_chief': self.user.pk

--- a/events/urls/cal.py
+++ b/events/urls/cal.py
@@ -1,0 +1,12 @@
+from django.conf.urls import url
+
+from .. import cal
+from ..views import list as list_views
+
+urlpatterns = [
+    url(r'^$', list_views.public_facing, name="list"),
+    url(r'^feed.ics$', cal.EventFeed(), name='feed'),
+    url(r'^feed_full.ics$', cal.FullEventFeed(), name='feed-full'),
+    url(r'^feed_light.ics$', cal.LightEventFeed(), name='feed-light'),
+    url(r'^json(/*?.*)*$', cal.cal_json, name="api"),
+]

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -38,4 +38,5 @@ urlpatterns = [
     url(r'^edit/(?P<id>[0-9a-f]+)/$', mkedrm_views.eventnew, name="edit"),
     url(r'^approve/(?P<id>[0-9a-f]+)/$', flow_views.approval, name="approve"),
     url(r'^deny/(?P<id>[0-9a-f]+)/$', flow_views.denial, name="deny"),
+    url(r'^review/(?P<id>[0-9a-f]+)/$', flow_views.review, name="review"),
 ]

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -43,6 +43,11 @@ urlpatterns = [
     url(r'^close/(?P<id>[0-9a-f]+)/$', flow_views.close, name="close"),
     url(r'^cancel/(?P<id>[0-9a-f]+)/$', flow_views.cancel, name="cancel"),
     url(r'^reopen/(?P<id>[0-9a-f]+)/$', flow_views.reopen, name="reopen"),
+    url(r'^crew/(?P<id>[0-9a-f]+)/$', flow_views.assigncrew, name="add-crew"),
+    url(r'^rmcrew/(?P<id>[0-9a-f]+)/(?P<user>[0-9a-f]+)/$',
+        flow_views.rmcrew, name="remove-crew"),
+    url(r'^(?P<id>[0-9]+)/hours/bulk/$', flow_views.hours_bulk_admin,
+        name="add-bulk-crew"),
 
     # The nice url structure. TODO: fit the rest in here (with deprecation, of course)
     url(r'^view/(?P<event>[0-9]+)/', include([

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -1,6 +1,6 @@
 from django.conf.urls import include, url
 
-from ..views import list as list_views
+from ..views import list as list_views, flow as flow_views
 
 
 def generate_date_patterns(func, name):
@@ -24,4 +24,9 @@ urlpatterns = [
     url(r'^paid/', generate_date_patterns(list_views.paid, name="paid")),
     url(r'^unpaid/', generate_date_patterns(list_views.unpaid, name="unpaid")),
     url(r'^closed/', generate_date_patterns(list_views.closed, name="closed")),
+
+    # Actual event pages
+    # TODO: make a url structure that doesn't suck.
+
+    url(r'^view/(?P<id>[0-9a-f]+)/$', flow_views.viewevent, name="detail"),
 ]

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -42,4 +42,5 @@ urlpatterns = [
     url(r'^review/(?P<id>[0-9a-f]+)/remind/(?P<uid>[0-9a-f]+)/$',
         flow_views.reviewremind, name="remind"),
     url(r'^close/(?P<id>[0-9a-f]+)/$', flow_views.close, name="close"),
+    url(r'^cancel/(?P<id>[0-9a-f]+)/$', flow_views.cancel, name="cancel"),
 ]

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -27,7 +27,6 @@ urlpatterns = [
     url(r'^closed/', generate_date_patterns(list_views.closed, name="closed")),
 
     # Actual event pages
-    # TODO: make a url structure that doesn't suck.
 
     url(r'^view/(?P<id>[0-9a-f]+)/$', flow_views.viewevent, name="detail"),
     url(r'^pdf/(?P<ids>\d+(,\d+)*)?/?$', pdf_views.generate_event_pdf_multi,
@@ -44,8 +43,8 @@ urlpatterns = [
     url(r'^close/(?P<id>[0-9a-f]+)/$', flow_views.close, name="close"),
     url(r'^cancel/(?P<id>[0-9a-f]+)/$', flow_views.cancel, name="cancel"),
     url(r'^reopen/(?P<id>[0-9a-f]+)/$', flow_views.reopen, name="reopen"),
-    url(r'^view/(?P<id>[0-9]+)/billing/pdf/$', pdf_views.generate_event_bill_pdf,
-        name="pdf-bill"),
+
+    # The nice url structure. TODO: fit the rest in here (with deprecation, of course)
     url(r'^view/(?P<event>[0-9]+)/', include([
         url(r'^billing/', view=include([
             url(r'^mk/$', flow_views.BillingCreate.as_view(), name="new"),
@@ -53,6 +52,7 @@ urlpatterns = [
                 name="edit"),
             url(r'^rm/(?P<pk>[0-9]+)/$', flow_views.BillingDelete.as_view(),
                 name="remove"),
+            url(r'^pdf/$', pdf_views.generate_event_bill_pdf, name="pdf"),
         ], namespace="bills")),
         url(r'^report/', view=include([
             url(r'^mk/$', flow_views.CCRCreate.as_view(), name="new"),

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -41,4 +41,5 @@ urlpatterns = [
     url(r'^review/(?P<id>[0-9a-f]+)/$', flow_views.review, name="review"),
     url(r'^review/(?P<id>[0-9a-f]+)/remind/(?P<uid>[0-9a-f]+)/$',
         flow_views.reviewremind, name="remind"),
+    url(r'^close/(?P<id>[0-9a-f]+)/$', flow_views.close, name="close"),
 ]

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -39,4 +39,6 @@ urlpatterns = [
     url(r'^approve/(?P<id>[0-9a-f]+)/$', flow_views.approval, name="approve"),
     url(r'^deny/(?P<id>[0-9a-f]+)/$', flow_views.denial, name="deny"),
     url(r'^review/(?P<id>[0-9a-f]+)/$', flow_views.review, name="review"),
+    url(r'^review/(?P<id>[0-9a-f]+)/remind/(?P<uid>[0-9a-f]+)/$',
+        flow_views.reviewremind, name="remind"),
 ]

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -36,4 +36,5 @@ urlpatterns = [
     # url(r'^db/events/mk/$', 'events.views.mkedrm.eventnew', name="event-new"),
     url(r'^mk/$', mkedrm_views.eventnew, name="new"),
     url(r'^edit/(?P<id>[0-9a-f]+)/$', mkedrm_views.eventnew, name="edit"),
+    url(r'^approve/(?P<id>[0-9a-f]+)/$', flow_views.approval, name="approve"),
 ]

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -43,4 +43,5 @@ urlpatterns = [
         flow_views.reviewremind, name="remind"),
     url(r'^close/(?P<id>[0-9a-f]+)/$', flow_views.close, name="close"),
     url(r'^cancel/(?P<id>[0-9a-f]+)/$', flow_views.cancel, name="cancel"),
+    url(r'^reopen/(?P<id>[0-9a-f]+)/$', flow_views.reopen, name="reopen"),
 ]

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -48,6 +48,8 @@ urlpatterns = [
         flow_views.rmcrew, name="remove-crew"),
     url(r'^(?P<id>[0-9]+)/hours/bulk/$', flow_views.hours_bulk_admin,
         name="add-bulk-crew"),
+    url(r'^crewchief/(?P<id>[0-9a-f]+)/$', flow_views.assigncc, name="chiefs"),
+    url(r'^rmcc/(?P<id>[0-9a-f]+)/(?P<user>[0-9a-f]+)/$', flow_views.rmcc, name="remove-chief"),
 
     # The nice url structure. TODO: fit the rest in here (with deprecation, of course)
     url(r'^view/(?P<event>[0-9]+)/', include([

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -1,6 +1,7 @@
 from django.conf.urls import include, url
 
 from ..views import list as list_views, flow as flow_views
+from pdfs import views as pdf_views
 
 
 def generate_date_patterns(func, name):
@@ -29,4 +30,7 @@ urlpatterns = [
     # TODO: make a url structure that doesn't suck.
 
     url(r'^view/(?P<id>[0-9a-f]+)/$', flow_views.viewevent, name="detail"),
+    url(r'^pdf/(?P<ids>\d+(,\d+)*)?/?$', pdf_views.generate_event_pdf_multi,
+        name="pdf-multi"),
+    url(r'^view/(?P<id>[0-9a-f]+)/pdf/$', pdf_views.generate_event_pdf, name="pdf"),
 ]

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -37,4 +37,5 @@ urlpatterns = [
     url(r'^mk/$', mkedrm_views.eventnew, name="new"),
     url(r'^edit/(?P<id>[0-9a-f]+)/$', mkedrm_views.eventnew, name="edit"),
     url(r'^approve/(?P<id>[0-9a-f]+)/$', flow_views.approval, name="approve"),
+    url(r'^deny/(?P<id>[0-9a-f]+)/$', flow_views.denial, name="deny"),
 ]

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -50,6 +50,8 @@ urlpatterns = [
         name="add-bulk-crew"),
     url(r'^crewchief/(?P<id>[0-9a-f]+)/$', flow_views.assigncc, name="chiefs"),
     url(r'^rmcc/(?P<id>[0-9a-f]+)/(?P<user>[0-9a-f]+)/$', flow_views.rmcc, name="remove-chief"),
+    url(r'^attachments/(?P<id>[0-9a-f]+)/$', flow_views.assignattach,
+        name="files"),
 
     # The nice url structure. TODO: fit the rest in here (with deprecation, of course)
     url(r'^view/(?P<event>[0-9]+)/', include([

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -47,6 +47,13 @@ urlpatterns = [
     url(r'^view/(?P<id>[0-9]+)/billing/pdf/$', pdf_views.generate_event_bill_pdf,
         name="pdf-bill"),
     url(r'^view/(?P<event>[0-9]+)/', include([
+        url(r'^billing/', view=include([
+            url(r'^mk/$', flow_views.BillingCreate.as_view(), name="new"),
+            url(r'^update/(?P<pk>[0-9]+)/$', flow_views.BillingUpdate.as_view(),
+                name="edit"),
+            url(r'^rm/(?P<pk>[0-9]+)/$', flow_views.BillingDelete.as_view(),
+                name="remove"),
+        ], namespace="bills")),
         url(r'^report/', view=include([
             url(r'^mk/$', flow_views.CCRCreate.as_view(), name="new"),
             url(r'^update/(?P<pk>[0-9]+)/$', flow_views.CCRUpdate.as_view(),

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -1,6 +1,6 @@
 from django.conf.urls import include, url
 
-from ..views import list as list_views, flow as flow_views
+from ..views import list as list_views, flow as flow_views, mkedrm as mkedrm_views
 from pdfs import views as pdf_views
 
 
@@ -33,4 +33,7 @@ urlpatterns = [
     url(r'^pdf/(?P<ids>\d+(,\d+)*)?/?$', pdf_views.generate_event_pdf_multi,
         name="pdf-multi"),
     url(r'^view/(?P<id>[0-9a-f]+)/pdf/$', pdf_views.generate_event_pdf, name="pdf"),
+    # url(r'^db/events/mk/$', 'events.views.mkedrm.eventnew', name="event-new"),
+    url(r'^mk/$', mkedrm_views.eventnew, name="new"),
+    url(r'^edit/(?P<id>[0-9a-f]+)/$', mkedrm_views.eventnew, name="edit"),
 ]

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -52,6 +52,8 @@ urlpatterns = [
     url(r'^rmcc/(?P<id>[0-9a-f]+)/(?P<user>[0-9a-f]+)/$', flow_views.rmcc, name="remove-chief"),
     url(r'^attachments/(?P<id>[0-9a-f]+)/$', flow_views.assignattach,
         name="files"),
+    url(r'^extras/(?P<id>[0-9a-f]+)/$', flow_views.extras, name="extras"),
+    url(r'^oneoff/(?P<id>[0-9a-f]+)/$', flow_views.oneoff, name="oneoffs"),
 
     # The nice url structure. TODO: fit the rest in here (with deprecation, of course)
     url(r'^view/(?P<event>[0-9]+)/', include([

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -44,4 +44,14 @@ urlpatterns = [
     url(r'^close/(?P<id>[0-9a-f]+)/$', flow_views.close, name="close"),
     url(r'^cancel/(?P<id>[0-9a-f]+)/$', flow_views.cancel, name="cancel"),
     url(r'^reopen/(?P<id>[0-9a-f]+)/$', flow_views.reopen, name="reopen"),
+    url(r'^view/(?P<id>[0-9]+)/billing/pdf/$', pdf_views.generate_event_bill_pdf,
+        name="pdf-bill"),
+    url(r'^view/(?P<event>[0-9]+)/', include([
+        url(r'^report/', view=include([
+            url(r'^mk/$', flow_views.CCRCreate.as_view(), name="new"),
+            url(r'^update/(?P<pk>[0-9]+)/$', flow_views.CCRUpdate.as_view(),
+                name="edit"),
+            url(r'^rm/(?P<pk>[0-9]+)/$', flow_views.CCRDelete.as_view(), name="remove")
+        ], namespace="reports")),
+    ]))
 ]

--- a/events/urls/my.py
+++ b/events/urls/my.py
@@ -17,4 +17,8 @@ urlpatterns = [
             name="org-accept"),
     ])),
 
+    url(r'^events/', include([
+        url(r'^$', views.my.myevents, name="events"),
+    ]))
+
 ]

--- a/events/urls/my.py
+++ b/events/urls/my.py
@@ -20,8 +20,19 @@ urlpatterns = [
     url(r'^events/', include([
         url(r'^$', views.my.myevents, name="events"),
 
-        # TODO: move these
+        # TODO: merge these with their events equivalents.
         url(r'^(?P<eventid>[0-9]+)/files/$', views.my.eventfiles, name="event-files"),
+        url(r'^(?P<eventid>[0-9]+)/report/$', views.my.ccreport, name="report"),
+        url(r'^(?P<eventid>[0-9]+)/hours/$', views.my.hours_list, name="hours-list"),
+        url(r'^(?P<eventid>[0-9]+)/hours/bulk/$', views.my.hours_bulk,
+            name="hours-bulk"),
+        url(r'^(?P<eventid>[0-9]+)/hours/mk/$', views.my.hours_mk,
+            name="hours-new"),
+        url(r'^(?P<eventid>[0-9]+)/hours/(?P<userid>[0-9]+)$', views.my.hours_edit,
+            name="hours-edit"),
+
+        # TODO: kill this with fire "foo.bar"
+        url(r'^(?P<eventid>[0-9]+)/repeat/$', views.my.myworepeat, name="repeat"),
     ]))
 
 ]

--- a/events/urls/my.py
+++ b/events/urls/my.py
@@ -19,6 +19,9 @@ urlpatterns = [
 
     url(r'^events/', include([
         url(r'^$', views.my.myevents, name="events"),
+
+        # TODO: move these
+        url(r'^(?P<eventid>[0-9]+)/files/$', views.my.eventfiles, name="event-files"),
     ]))
 
 ]

--- a/events/urls/my.py
+++ b/events/urls/my.py
@@ -11,6 +11,10 @@ urlpatterns = [
         url(r'^$', views.my.myorgs, name="orgs"),
         url(r'^form/$', views.my.myorgform, name="org-request"),
         url(r'^(?P<id>[0-9a-f]+)/$', views.orgs.orgedit, name="org-edit"),
+        url(r'^transfer/(?P<id>[0-9]+)/$', views.orgs.org_mkxfer, name="org-transfer"),
+        # ..... TODO: don't guess whether we're transfering or accepting
+        url(r'^transfer/(?P<idstr>[0-9a-f]+)/$', views.orgs.org_acceptxfer,
+            name="org-accept"),
     ])),
 
 ]

--- a/events/urls/wizard.py
+++ b/events/urls/wizard.py
@@ -1,0 +1,22 @@
+from django.contrib.auth.decorators import login_required
+from django.conf.urls import url
+
+from ..views import wizard
+from .. import forms
+
+event_wizard = wizard.EventWizard.as_view(
+    forms.named_event_forms,
+    url_name='wizard:step',
+    done_step_name='finished',
+    condition_dict={
+        'lighting': wizard.show_lighting_form_condition,
+        'sound': wizard.show_sound_form_condition,
+        'projection': wizard.show_projection_form_condition,
+        'other': wizard.show_other_services_form_condition,
+    }
+)
+
+urlpatterns = [
+    url(r'^(?P<step>.+)/$', login_required(event_wizard), name='step'),
+    url(r'^$', login_required(event_wizard), name='start'),
+]

--- a/events/views/flow.py
+++ b/events/views/flow.py
@@ -164,7 +164,7 @@ def reviewremind(request, id, uid):
         email_body = 'This is a reminder that you have a pending crew chief report for "%s" \n' \
                      ' Please Visit %s%s to complete it' % (event.event_name,
                                                             request.get_host(),
-                                                            reverse("my-ccreport", args=[event.id]))
+                                                            reverse("my:report", args=[event.id]))
         email = DLEG(subject="LNL Crew Chief Report Reminder Email", to_emails=[cci.crew_chief.email], body=email_body,
                      attachments=attachments)
         email.send()

--- a/events/views/flow.py
+++ b/events/views/flow.py
@@ -239,7 +239,7 @@ def rmcrew(request, id, user):
             request.user.has_perm('events.edit_event_hours', event)):
         raise PermissionDenied
     event.crew.remove(user)
-    return HttpResponseRedirect(reverse('events.views.flow.assigncrew', args=(event.id,)))
+    return HttpResponseRedirect(reverse("events:add-crew", args=(event.id,)))
 
 
 @login_required

--- a/events/views/flow.py
+++ b/events/views/flow.py
@@ -307,7 +307,7 @@ def rmcc(request, id, user):
             request.user.has_perm('events.edit_event_hours', event)):
         raise PermissionDenied
     event.crew_chief.remove(user)
-    return HttpResponseRedirect(reverse('events.views.flow.assigncc', args=(event.id,)))
+    return HttpResponseRedirect(reverse("events:chiefs", args=(event.id,)))
 
 
 @login_required

--- a/events/views/flow.py
+++ b/events/views/flow.py
@@ -169,7 +169,7 @@ def reviewremind(request, id, uid):
                      attachments=attachments)
         email.send()
         messages.add_message(request, messages.INFO, 'Reminder Sent')
-        return HttpResponseRedirect(reverse('event-review', args=(event.id,)))
+        return HttpResponseRedirect(reverse("events:review", args=(event.id,)))
     else:
         return HttpResponse("Bad Call")
 

--- a/events/views/flow.py
+++ b/events/views/flow.py
@@ -35,7 +35,7 @@ def approval(request, id):
         raise PermissionDenied
     if event.approved:
         messages.add_message(request, messages.INFO, 'Event has already been approved!')
-        return HttpResponseRedirect(reverse('events.views.flow.viewevent', args=(event.id,)))
+        return HttpResponseRedirect(reverse('events:detail', args=(event.id,)))
 
     if request.method == 'POST':
         form = EventApprovalForm(request.POST, instance=event)
@@ -56,7 +56,7 @@ def approval(request, id):
                 messages.add_message(request, messages.INFO,
                                      'No contact info on file for approval. Please give them the good news!')
 
-            return HttpResponseRedirect(reverse('events.views.flow.viewevent', args=(e.id,)))
+            return HttpResponseRedirect(reverse('events:detail', args=(e.id,)))
         else:
             context['formset'] = form
     else:
@@ -78,7 +78,7 @@ def denial(request, id):
         raise PermissionDenied
     if event.cancelled:
         messages.add_message(request, messages.INFO, 'Event has already been cancelled!')
-        return HttpResponseRedirect(reverse('events.views.flow.viewevent', args=(event.id,)))
+        return HttpResponseRedirect(reverse('events:detail', args=(event.id,)))
 
     if request.method == 'POST':
         form = EventDenialForm(request.POST, instance=event)
@@ -101,7 +101,7 @@ def denial(request, id):
             else:
                 messages.add_message(request, messages.INFO,
                                      'No contact info on file for denial. Please give them the bad news.')
-            return HttpResponseRedirect(reverse('events.views.flow.viewevent', args=(e.id,)))
+            return HttpResponseRedirect(reverse('events:detail', args=(e.id,)))
         else:
             context['formset'] = form
     else:
@@ -121,7 +121,7 @@ def review(request, id):
 
     if event.reviewed:
         messages.add_message(request, messages.INFO, 'Event has already been reviewed!')
-        return HttpResponseRedirect(reverse('events.views.flow.viewevent', args=(event.id,)))
+        return HttpResponseRedirect(reverse('events:detail', args=(event.id,)))
 
     context['event'] = event
 
@@ -136,7 +136,7 @@ def review(request, id):
             # confirm with user
             messages.add_message(request, messages.INFO, 'Event has been reviewed and is ready for billing!')
 
-            return HttpResponseRedirect(reverse('events.views.flow.viewevent', args=(e.id,)) + "#billing")
+            return HttpResponseRedirect(reverse('events:detail', args=(e.id,)) + "#billing")
         else:
             context['formset'] = form
     else:
@@ -187,7 +187,7 @@ def close(request, id):
 
     event.save()
 
-    return HttpResponseRedirect(reverse('events.views.flow.viewevent', args=(event.id,)))
+    return HttpResponseRedirect(reverse('events:detail', args=(event.id,)))
 
 
 @login_required
@@ -213,7 +213,7 @@ def cancel(request, id):
         email_body += " or try them at %s." % request.user.email
     email = DLEG(subject="Event Cancelled", to_emails=targets, body=email_body, bcc=[settings.EMAIL_TARGET_VP])
     email.send()
-    return HttpResponseRedirect(reverse('events.views.flow.viewevent', args=(event.id,)))
+    return HttpResponseRedirect(reverse('events:detail', args=(event.id,)))
 
 
 @login_required
@@ -229,7 +229,7 @@ def reopen(request, id):
 
     event.save()
 
-    return HttpResponseRedirect(reverse('events.views.flow.viewevent', args=(event.id,)))
+    return HttpResponseRedirect(reverse('events:detail', args=(event.id,)))
 
 
 @login_required
@@ -257,7 +257,7 @@ def assigncrew(request, id):
         formset = CrewAssign(request.POST, instance=event)
         if formset.is_valid():
             formset.save()
-            return HttpResponseRedirect(reverse('events.views.flow.viewevent', args=(event.id,)))
+            return HttpResponseRedirect(reverse('events:detail', args=(event.id,)))
         else:
             context['formset'] = formset
 
@@ -288,7 +288,7 @@ def hours_bulk_admin(request, id):
         formset = mk_hours_formset(request.POST, instance=event)
         if formset.is_valid():
             formset.save()
-            return HttpResponseRedirect(reverse('events.views.flow.viewevent', args=(event.id,)))
+            return HttpResponseRedirect(reverse('events:detail', args=(event.id,)))
         else:
             context['formset'] = formset
 
@@ -330,7 +330,7 @@ def assigncc(request, id):
         formset = cc_formset(request.POST, instance=event)
         if formset.is_valid():
             formset.save()
-            return HttpResponseRedirect(reverse('events.views.flow.viewevent', args=(event.id,)))
+            return HttpResponseRedirect(reverse('events:detail', args=(event.id,)))
         else:
             context['formset'] = formset
 
@@ -360,7 +360,7 @@ def assignattach(request, id):
         formset = att_formset(request.POST, request.FILES, instance=event)
         if formset.is_valid():
             formset.save()
-            return HttpResponseRedirect(reverse('events.views.flow.viewevent', args=(event.id,)))
+            return HttpResponseRedirect(reverse('events:detail', args=(event.id,)))
         else:
             context['formset'] = formset
 
@@ -428,7 +428,7 @@ def extras(request, id):
         formset = mk_extra_formset(request.POST, request.FILES, instance=event)
         if formset.is_valid():
             formset.save()
-            return HttpResponseRedirect(reverse('events.views.flow.viewevent', args=(event.id,)) + "#billing")
+            return HttpResponseRedirect(reverse('events:detail', args=(event.id,)) + "#billing")
         else:
             context['formset'] = formset
 
@@ -459,7 +459,7 @@ def oneoff(request, id):
         formset = mk_oneoff_formset(request.POST, request.FILES, instance=event)
         if formset.is_valid():
             formset.save()
-            return HttpResponseRedirect(reverse('events.views.flow.viewevent', args=(event.id,)) + "#billing")
+            return HttpResponseRedirect(reverse('events:detail', args=(event.id,)) + "#billing")
         else:
             context['formset'] = formset
 
@@ -501,7 +501,7 @@ class CCRCreate(SetFormMsgMixin, HasPermMixin, ConditionalFormMixin, LoginRequir
         return super(CCRCreate, self).form_valid(form)
 
     def get_success_url(self):
-        return reverse("events-detail", args=(self.kwargs['event'],))
+        return reverse("events:detail", args=(self.kwargs['event'],))
 
 
 class CCRUpdate(SetFormMsgMixin, ConditionalFormMixin, HasPermMixin, LoginRequiredMixin, UpdateView):
@@ -522,7 +522,7 @@ class CCRUpdate(SetFormMsgMixin, ConditionalFormMixin, HasPermMixin, LoginRequir
         return super(CCRUpdate, self).form_valid(form)
 
     def get_success_url(self):
-        return reverse("events-detail", args=(self.kwargs['event'],))
+        return reverse("events:detail", args=(self.kwargs['event'],))
 
 
 class CCRDelete(SetFormMsgMixin, HasPermMixin, LoginRequiredMixin, DeleteView):
@@ -540,7 +540,7 @@ class CCRDelete(SetFormMsgMixin, HasPermMixin, LoginRequiredMixin, DeleteView):
             return obj
 
     def get_success_url(self):
-        return reverse("events-detail", args=(self.kwargs['event'],))
+        return reverse("events:detail", args=(self.kwargs['event'],))
 
 
 class BillingCreate(SetFormMsgMixin, HasPermMixin, LoginRequiredMixin, CreateView):
@@ -572,7 +572,7 @@ class BillingCreate(SetFormMsgMixin, HasPermMixin, LoginRequiredMixin, CreateVie
         return super(BillingCreate, self).form_valid(form)
 
     def get_success_url(self):
-        return reverse("events-detail", args=(self.kwargs['event'],)) + "#billing"
+        return reverse("events:detail", args=(self.kwargs['event'],)) + "#billing"
 
 
 class BillingUpdate(SetFormMsgMixin, HasPermMixin, LoginRequiredMixin, UpdateView):
@@ -594,7 +594,7 @@ class BillingUpdate(SetFormMsgMixin, HasPermMixin, LoginRequiredMixin, UpdateVie
         return super(BillingUpdate, self).form_valid(form)
 
     def get_success_url(self):
-        return reverse("events-detail", args=(self.kwargs['event'],)) + "#billing"
+        return reverse("events:detail", args=(self.kwargs['event'],)) + "#billing"
 
 
 class BillingDelete(HasPermMixin, LoginRequiredMixin, DeleteView):
@@ -612,4 +612,4 @@ class BillingDelete(HasPermMixin, LoginRequiredMixin, DeleteView):
             return obj
 
     def get_success_url(self):
-        return reverse("events-detail", args=(self.kwargs['event'],)) + "#billing"
+        return reverse("events:detail", args=(self.kwargs['event'],)) + "#billing"

--- a/events/views/list.py
+++ b/events/views/list.py
@@ -196,7 +196,7 @@ def upcoming(request, start=None, end=None):
     context['h2'] = "Upcoming Events"
     context['events'] = events
     context['baseurl'] = reverse("events:upcoming")
-    context['pdfurl'] = reverse('events-pdf-multi-empty')
+    context['pdfurl'] = reverse('events:pdf-multi')
     context['cols'] = ['event_name',
                        'org',
                        'location',
@@ -235,7 +235,7 @@ def incoming(request, start=None, end=None):
     context['h2'] = "Incoming Events"
     context['events'] = events
     context['baseurl'] = reverse("events:incoming")
-    context['pdfurl'] = reverse('events-pdf-multi-empty')
+    context['pdfurl'] = reverse('events:pdf-multi')
     context['cols'] = ['event_name',
                        'org',
                        'location',
@@ -276,7 +276,7 @@ def openworkorders(request, start=None, end=None):
     context['h2'] = "Open Events"
     context['events'] = events
     context['baseurl'] = reverse("events:open")
-    context['pdfurl'] = reverse('events-pdf-multi-empty')
+    context['pdfurl'] = reverse('events:pdf-multi')
     context['cols'] = ['event_name',
                        'org',
                        'location',
@@ -327,7 +327,7 @@ def findchief(request, start=None, end=None):
     context['proj_hideable'] = True
     context['events'] = events
     context['baseurl'] = reverse("events:findchief")
-    context['pdfurl'] = reverse('events-pdf-multi-empty')
+    context['pdfurl'] = reverse('events:pdf-multi')
     context['cols'] = ['event_name',
                        'org',
                        'location',
@@ -379,7 +379,7 @@ def unreviewed(request, start=None, end=None):
     context['h2'] = "Events Pending Billing Review"
     context['events'] = events
     context['baseurl'] = reverse("events:unreviewed")
-    context['pdfurl'] = reverse('events-pdf-multi-empty')
+    context['pdfurl'] = reverse('events:pdf-multi')
     context['proj_hideable'] = True
     context['cols'] = ['event_name',
                        'org',
@@ -432,7 +432,7 @@ def unbilled(request, start=None, end=None):
     context['events'] = events
     context['baseurl'] = reverse("events:unbilled")
     context['proj_hideable'] = True
-    context['pdfurl'] = reverse('events-pdf-multi-empty')
+    context['pdfurl'] = reverse('events:pdf-multi')
     context['cols'] = ['event_name',
                        'org',
                        'location',
@@ -478,7 +478,7 @@ def unbilled_semester(request, start=None, end=None):
     context['h2'] = "Events to be Billed (Films)"
     context['events'] = events
     context['baseurl'] = reverse("events:unbilled-semester")
-    context['pdfurl'] = reverse('events-pdf-multi-empty')
+    context['pdfurl'] = reverse('events:pdf-multi')
     context['cols'] = ['event_name',
                        'org',
                        'location',
@@ -524,7 +524,7 @@ def paid(request, start=None, end=None):
     context['h2'] = "Paid Events"
     context['events'] = events
     context['baseurl'] = reverse("events:paid")
-    context['pdfurl'] = reverse('events-pdf-multi-empty')
+    context['pdfurl'] = reverse('events:pdf-multi')
     context['proj_hideable'] = True
     context['cols'] = ['event_name',
                        'org',
@@ -573,7 +573,7 @@ def unpaid(request, start=None, end=None):
     context['events'] = events
     context['baseurl'] = reverse("events:unpaid")
     context['proj_hideable'] = True
-    context['pdfurl'] = reverse('events-pdf-multi-empty')
+    context['pdfurl'] = reverse('events:pdf-multi')
     context['cols'] = ['event_name',
                        'org',
                        FakeExtendedField('datetime_start', verbose_name="Event Time"),
@@ -612,7 +612,7 @@ def closed(request, start=None, end=None):
     context['events'] = events
     context['baseurl'] = reverse("events:closed")
     context['proj_hideable'] = True
-    context['pdfurl'] = reverse('events-pdf-multi-empty')
+    context['pdfurl'] = reverse('events:pdf-multi')
     context['cols'] = ['event_name',
                        'org',
                        'location',

--- a/events/views/mkedrm.py
+++ b/events/views/mkedrm.py
@@ -43,7 +43,7 @@ def eventnew(request, id=None):
                 res.submitted_ip = request.META.get('REMOTE_ADDR')
                 res.save()
                 form.save_m2m()
-            return HttpResponseRedirect(reverse('events.views.flow.viewevent', args=(res.id,)))
+            return HttpResponseRedirect(reverse('events:detail', args=(res.id,)))
         else:
             context['e'] = form.errors
             context['formset'] = form

--- a/events/views/my.py
+++ b/events/views/my.py
@@ -250,7 +250,7 @@ def hours_mk(request, eventid):
         formset = MKHoursForm(event, request.POST)
         if formset.is_valid():
             formset.save()
-            return HttpResponseRedirect(reverse('my-cchours', args=(event.id,)))
+            return HttpResponseRedirect(reverse("my:hours-list", args=(event.id,)))
         else:
             context['formset'] = formset
 
@@ -284,7 +284,7 @@ def hours_edit(request, eventid, userid):
         formset = EditHoursForm(request.POST, instance=hours)
         if formset.is_valid():
             formset.save()
-            return HttpResponseRedirect(reverse('my-cchours', args=(event.id,)))
+            return HttpResponseRedirect(reverse("my:hours-list", args=(event.id,)))
         else:
             context['formset'] = formset
 
@@ -322,7 +322,7 @@ def hours_bulk(request, eventid):
         formset = mk_event_formset(request.POST, instance=event)
         if formset.is_valid():
             formset.save()
-            return HttpResponseRedirect(reverse('my-cchours', args=(event.id,)))
+            return HttpResponseRedirect(reverse("my:hours-list", args=(event.id,)))
         else:
             context['formset'] = formset
 

--- a/events/views/my.py
+++ b/events/views/my.py
@@ -128,7 +128,6 @@ def myorgform(request):
 # lnl facing
 
 @login_required
-# @user_passes_test(is_lnlmember, login_url='/lnldb/fuckoffkitty/')
 def myevents(request):
     """ List Events That Have been CC'd / involved """
     context = {'user': request.user, 'now': datetime.datetime.now(timezone.get_current_timezone()),

--- a/events/views/my.py
+++ b/events/views/my.py
@@ -199,7 +199,7 @@ def ccreport(request, eventid):
         formset = InternalReportForm(data=request.POST, event=event, request_user=user, instance=report)
         if formset.is_valid():
             formset.save()
-            return HttpResponseRedirect(reverse('my-events'))
+            return HttpResponseRedirect(reverse("my:events"))
         else:
             context['formset'] = formset
 

--- a/events/views/orgs.py
+++ b/events/views/orgs.py
@@ -70,7 +70,7 @@ def addeditorgs(request, org_id=None):
         if formset.is_valid():
             org = formset.save()
             messages.add_message(request, messages.SUCCESS, 'Changes saved.')
-            # return HttpResponseRedirect(reverse('events.views.admin', kwargs={'msg':SUCCESS_MSG_ORG}))
+            # return HttpResponseRedirect(reverse("home", kwargs={'msg':SUCCESS_MSG_ORG}))
             return HttpResponseRedirect(reverse('orgs:detail', kwargs={'org_id': org.pk}))
         else:
             context['formset'] = formset
@@ -115,7 +115,7 @@ def fund_edit(request, fund_id=None, org=None):
                     return HttpResponseRedirect(reverse('orgs:detail', args=(org,)))
                 except ObjectDoesNotExist:
                     messages.add_message(request, messages.ERROR, 'Failed to add fund to organization.')
-            # return HttpResponseRedirect(reverse('events.views.admin', kwargs={'msg':SUCCESS_MSG_ORG}))
+            # return HttpResponseRedirect(reverse("home", kwargs={'msg':SUCCESS_MSG_ORG}))
             return HttpResponseRedirect(reverse('orgs:list'))
         else:
             context['formset'] = formset
@@ -169,7 +169,7 @@ def orgedit(request, id):
         formset = ExternalOrgUpdateForm(request.POST, instance=org)
         if formset.is_valid():
             formset.save()
-            # return HttpResponseRedirect(reverse('events.views.admin', kwargs={'msg':SUCCESS_MSG_ORG}))
+            # return HttpResponseRedirect(reverse("home", kwargs={'msg':SUCCESS_MSG_ORG}))
             return HttpResponseRedirect(reverse('events.views.orgs.orglist'))
 
         else:

--- a/events/views/orgs.py
+++ b/events/views/orgs.py
@@ -170,7 +170,7 @@ def orgedit(request, id):
         if formset.is_valid():
             formset.save()
             # return HttpResponseRedirect(reverse("home", kwargs={'msg':SUCCESS_MSG_ORG}))
-            return HttpResponseRedirect(reverse('events.views.orgs.orglist'))
+            return HttpResponseRedirect(reverse('orgs:list'))
 
         else:
             context['formset'] = formset

--- a/events/views/wizard.py
+++ b/events/views/wizard.py
@@ -39,7 +39,7 @@ class EventWizard(NamedUrlSessionWizardView):
     def done(self, form_list, **kwargs):
         # return HttpResponse([form.cleaned_data for form in form_list])
         event = Event.event_mg.consume_workorder_formwiz(form_list, self)
-        # return HttpResponseRedirect(reverse('events.views.my.myeventdetail',args=(event.id,)))
+        # return HttpResponseRedirect(reverse('events:detail',args=(event.id,)))
         email_body = "You have successfully submitted an event titled %s" % event.event_name
         email = DLEG(subject="New Event Submitted", to_emails=[event.contact.email], body=email_body,
                      bcc=[settings.EMAIL_TARGET_VP])

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -309,7 +309,7 @@ def fast_mk(request):
 #         formset = InvForm(request.POST)
 #         if formset.is_valid():
 #             formset.save()
-#             # return HttpResponseRedirect(reverse('lnldb.events.views.admin',
+#             # return HttpResponseRedirect(reverse("home",
 #  kwargs={'msg':slugify(SUCCESS_MSG_INV)}))
 #             return HttpResponseRedirect(reverse('inventory:view'))
 #

--- a/lnldb/settings.py
+++ b/lnldb/settings.py
@@ -365,7 +365,7 @@ MARKDOWN_DEUX_STYLES = {
                                            )
              ),
             (re.compile("@([0-9]+)"),
-                lambda m: reverse_noexcept("events-detail",
+                lambda m: reverse_noexcept("events:detail",
                                            args=[m.group(1)]
                                            )
              ),

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -47,7 +47,7 @@ urlpatterns = [
     url(r'', include('accounts.urls', namespace='accounts')),
 
     # special urls
-    url(r'^db/$', db_home, name="db"),
+    url(r'^db/$', db_home, name="home"),
     url(r'^(?P<slug>[-\w]+)/$', view_page, name="page"),
     url(r'^db/oldsearch$', event_search, name="events-search"),
     url(r'^db/search$', data.views.search, name="search"),

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -125,8 +125,6 @@ urlpatterns = [
     # }}}
 
     # events {{{
-    url(r'^db/events/review/(?P<id>[0-9a-f]+)/remind/(?P<uid>[0-9a-f]+)/$',
-        'events.views.flow.reviewremind', name="event-review-remind"),
     url(r'^db/events/close/(?P<id>[0-9a-f]+)/$', 'events.views.flow.close', name="event-close"),
     url(r'^db/events/cancel/(?P<id>[0-9a-f]+)/$', 'events.views.flow.cancel', name="event-cancel"),
     url(r'^db/events/reopen/(?P<id>[0-9a-f]+)/$', 'events.views.flow.reopen', name="event-reopen"),

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -124,14 +124,7 @@ urlpatterns = [
     # }}}
 
     # events {{{
-    url(r'^db/events/crew/(?P<id>[0-9a-f]+)/$', 'events.views.flow.assigncrew'),
-    url(r'^db/events/rmcrew/(?P<id>[0-9a-f]+)/(?P<user>[0-9a-f]+)/$',
-        'events.views.flow.rmcrew'),
     url(r'^db/events/crewchief/(?P<id>[0-9a-f]+)/$', 'events.views.flow.assigncc'),
-
-    url(r'^db/events/(?P<id>[0-9]+)/hours/bulk/$', 'events.views.flow.hours_bulk_admin',
-        name="admin-cchours-bulk"),
-
     url(r'^db/events/attachments/(?P<id>[0-9a-f]+)/$', 'events.views.flow.assignattach',
         name="eventattachments"),
     url(r'^db/events/extras/(?P<id>[0-9a-f]+)/$', 'events.views.flow.extras',

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -48,7 +48,7 @@ urlpatterns = [
 
     # special urls
     url(r'^db/$', db_home, name="db"),
-    url(r'^(?P<slug>[-\w]+)/$', view_page),
+    url(r'^(?P<slug>[-\w]+)/$', view_page, name="page"),
     url(r'^db/oldsearch$', event_search, name="events-search"),
     url(r'^db/search$', data.views.search, name="search"),
 

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -9,12 +9,10 @@ from django.views.generic.base import RedirectView
 
 import data.views
 from emails.views import MeetingAnnounceCCView, MeetingAnnounceView
-from events.cal import EventFeed, FullEventFeed, LightEventFeed, cal_json
 from events.forms import named_event_forms
 from events.views.flow import CCRCreate, CCRDelete, CCRUpdate
 from events.views.indices import admin as db_home
 from events.views.indices import event_search
-from events.views.list import public_facing
 from pages.views import page as view_page
 
 admin.autodiscover()
@@ -44,6 +42,7 @@ urlpatterns = [
     url(r'^db/events/', include('events.urls.events', namespace='events')),
     url(r'^workorder/', include('events.urls.wizard', namespace='wizard')),
     url(r'^my/', include('events.urls.my', namespace='my')),
+    url(r'^list/', include('events.urls.cal', namespace='cal')),
     url(r'', include('accounts.urls', namespace='accounts')),
 
     # 'MY' {{{
@@ -62,14 +61,6 @@ urlpatterns = [
     url(r'^my/events/(?P<eventid>[0-9]+)/hours/(?P<userid>[0-9]+)$', 'events.views.my.hours_edit',
         name="my-cchours-edit"),
     url(r'^my/events/(?P<eventid>[0-9]+)/repeat/$', 'events.views.my.myworepeat', name="my-repeat"),
-    # }}}
-
-    # event lists {{{
-    url(r'^list/$', public_facing, name="list"),
-    url(r'^list/feed.ics$', EventFeed(), name='public_cal_feed'),
-    url(r'^list/feed_full.ics$', FullEventFeed(), name='full_cal_feed'),
-    url(r'^list/feed_light.ics$', LightEventFeed(), name='light_cal_feed'),
-    url(r'^list/json(/*?.*)*$', cal_json),
     # }}}
 
     # emails

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -125,7 +125,6 @@ urlpatterns = [
     # }}}
 
     # events {{{
-    url(r'^db/events/cancel/(?P<id>[0-9a-f]+)/$', 'events.views.flow.cancel', name="event-cancel"),
     url(r'^db/events/reopen/(?P<id>[0-9a-f]+)/$', 'events.views.flow.reopen', name="event-reopen"),
     url(r'^db/events/view/(?P<id>[0-9]+)/billing/pdf/$', 'pdfs.views.generate_event_bill_pdf',
         name="events-pdf-bill"),

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -5,7 +5,6 @@ from ajax_select import urls as ajax_select_urls
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
-from django.contrib.auth.decorators import login_required
 from django.views.generic.base import RedirectView
 
 import data.views
@@ -16,10 +15,6 @@ from events.views.flow import CCRCreate, CCRDelete, CCRUpdate
 from events.views.indices import admin as db_home
 from events.views.indices import event_search
 from events.views.list import public_facing
-from events.views.wizard import (EventWizard, show_lighting_form_condition,
-                                 show_other_services_form_condition,
-                                 show_projection_form_condition,
-                                 show_sound_form_condition)
 from pages.views import page as view_page
 from projection.views import (BulkUpdateView, ProjectionCreate,
                               ProjectionistDelete)
@@ -27,17 +22,6 @@ from projection.views import (BulkUpdateView, ProjectionCreate,
 admin.autodiscover()
 permission.autodiscover()
 
-event_wizard = EventWizard.as_view(
-    named_event_forms,
-    url_name='event_step',
-    done_step_name='finished',
-    condition_dict={
-        'lighting': show_lighting_form_condition,
-        'sound': show_sound_form_condition,
-        'projection': show_projection_form_condition,
-        'other': show_other_services_form_condition,
-    }
-)
 
 # Error pages
 handler403 = 'data.views.err403'
@@ -59,6 +43,7 @@ urlpatterns = [
     url(r'^db/clients/', include('events.urls.orgs', namespace='orgs')),
     url(r'^db/inventory/', include('inventory.urls', namespace='inventory')),
     url(r'^db/events/', include('events.urls.events', namespace='events')),
+    url(r'^workorder/', include('events.urls.wizard', namespace='wizard')),
     url(r'^my/', include('events.urls.my', namespace='my')),
     url(r'', include('accounts.urls', namespace='accounts')),
 
@@ -77,10 +62,6 @@ urlpatterns = [
         name="my-cchours-mk"),
     url(r'^my/events/(?P<eventid>[0-9]+)/hours/(?P<userid>[0-9]+)$', 'events.views.my.hours_edit',
         name="my-cchours-edit"),
-    # }}}
-    # workorders {{{
-    url(r'^workorder/(?P<step>.+)/$', login_required(event_wizard), name='event_step'),
-    url(r'^workorder/$', login_required(event_wizard), name='event'),
     url(r'^my/events/(?P<eventid>[0-9]+)/repeat/$', 'events.views.my.myworepeat', name="my-repeat"),
     # }}}
 

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -124,14 +124,12 @@ urlpatterns = [
     # }}}
 
     # events {{{
-    url(r'^db/events/crewchief/(?P<id>[0-9a-f]+)/$', 'events.views.flow.assigncc'),
     url(r'^db/events/attachments/(?P<id>[0-9a-f]+)/$', 'events.views.flow.assignattach',
         name="eventattachments"),
     url(r'^db/events/extras/(?P<id>[0-9a-f]+)/$', 'events.views.flow.extras',
         name="eventextras"),
     url(r'^db/events/oneoff/(?P<id>[0-9a-f]+)/$', 'events.views.flow.oneoff',
         name="eventoneoff"),
-    url(r'^db/events/rmcc/(?P<id>[0-9a-f]+)/(?P<user>[0-9a-f]+)/$', 'events.views.flow.rmcc'),
     # }}}
 
     # projection {{{

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -26,8 +26,8 @@ handler500 = 'data.views.err500'
 
 urlpatterns = [
     # Examples:
-    # url(r'^$', 'lnldb.views.home', name='home'),
-    # url(r'^lnldb/', include('lnldb.foo.urls')),
+    # url(r'^$', some_function, name='home'),
+    # url(r'^lnldb/', include('lnldb.foo.urls', [namespace='foo'])),
 
     # Include other modules
     url(r'^admin/', include(admin.site.urls)),
@@ -46,32 +46,13 @@ urlpatterns = [
     url(r'^email/', include('emails.urls', namespace='emails')),
     url(r'', include('accounts.urls', namespace='accounts')),
 
-    # 'MY' {{{
-    url(r'^my/events/(?P<eventid>[0-9]+)/report/$', 'events.views.my.ccreport', name="my-ccreport"),
-    url(r'^my/events/(?P<eventid>[0-9]+)/hours/$', 'events.views.my.hours_list', name="my-cchours"),
-    url(r'^my/events/(?P<eventid>[0-9]+)/hours/bulk/$', 'events.views.my.hours_bulk',
-        name="my-cchours-bulk"),
-    url(r'^my/events/(?P<eventid>[0-9]+)/hours/mk/$', 'events.views.my.hours_mk',
-        name="my-cchours-mk"),
-    url(r'^my/events/(?P<eventid>[0-9]+)/hours/(?P<userid>[0-9]+)$', 'events.views.my.hours_edit',
-        name="my-cchours-edit"),
-    url(r'^my/events/(?P<eventid>[0-9]+)/repeat/$', 'events.views.my.myworepeat', name="my-repeat"),
-    # }}}
-
-    # emails
-
     # special urls
     url(r'^db/$', db_home, name="db"),
     url(r'^(?P<slug>[-\w]+)/$', view_page),
     url(r'^db/oldsearch$', event_search, name="events-search"),
     url(r'^db/search$', data.views.search, name="search"),
 
-    # Uncomment to have javascript translation support
-    # url(r'^jsi18n', 'django.views.i18n.javascript_catalog'),
-
     # keep old urls
     url(r'^lnadmin/$', RedirectView.as_view(url="/db/", permanent=True)),
     url(r'^lnadmin/(?P<newpath>.+)$', RedirectView.as_view(url="/db/%(newpath)s", permanent=True)),
-
-    # debugging
 ]

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -107,8 +107,6 @@ urlpatterns = [
     url(r'^my/orgs/transfer/(?P<idstr>[0-9a-f]+)/$', 'events.views.orgs.org_acceptxfer',
         name="my-orgs-acceptxfer"),
     url(r'^my/events/$', 'events.views.my.myevents', name="my-events"),
-    url(r'^my/events/(?P<id>[0-9a-f]+)/pdf/$', 'pdfs.views.generate_event_pdf',
-        name="my-events-pdf"),
     url(r'^my/events/(?P<eventid>[0-9]+)/files/$', 'events.views.my.eventfiles',
         name="my-eventfiles"),
     url(r'^my/events/(?P<eventid>[0-9]+)/report/$', 'events.views.my.ccreport', name="my-ccreport"),
@@ -127,12 +125,6 @@ urlpatterns = [
     # }}}
 
     # events {{{
-    url(r'^db/events/view/(?P<id>[0-9a-f]+)/pdf/$', 'pdfs.views.generate_event_pdf',
-        name="events-pdf"),
-    url(r'^db/events/pdf/(?P<ids>\d+(,\d+)*)/$', 'pdfs.views.generate_event_pdf_multi',
-        name="events-pdf-multi"),
-    url(r'^db/events/pdf/$', 'pdfs.views.generate_event_pdf_multi',
-        name="events-pdf-multi-empty"),
     url(r'^db/events/mk/$', 'events.views.mkedrm.eventnew', name="event-new"),
     url(r'^db/events/edit/(?P<id>[0-9a-f]+)/$', 'events.views.mkedrm.eventnew',
         name="event-edit"),
@@ -187,7 +179,7 @@ urlpatterns = [
         name="projection-delete"),
     url(r'^db/projection/mk/$', ProjectionCreate.as_view(), name="projection-create"),
     url(r'^db/projection/list/detail/pdf/$', 'pdfs.views.generate_projection_pdf',
-        name="events-pdf-multi"),
+        name="proj-pdf-multi"),
 
     url(r'^db/projection/bulkevents/$', 'projection.views.bulk_projection',
         name="projection-bulk2"),

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -47,9 +47,6 @@ urlpatterns = [
     url(r'', include('accounts.urls', namespace='accounts')),
 
     # 'MY' {{{
-    url(r'^my/orgs/transfer/(?P<id>[0-9]+)/$', 'events.views.orgs.org_mkxfer', name="my-orgs-xfer"),
-    url(r'^my/orgs/transfer/(?P<idstr>[0-9a-f]+)/$', 'events.views.orgs.org_acceptxfer',
-        name="my-orgs-acceptxfer"),
     url(r'^my/events/$', 'events.views.my.myevents', name="my-events"),
     url(r'^my/events/(?P<eventid>[0-9]+)/files/$', 'events.views.my.eventfiles',
         name="my-eventfiles"),

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -43,6 +43,7 @@ urlpatterns = [
     url(r'^workorder/', include('events.urls.wizard', namespace='wizard')),
     url(r'^my/', include('events.urls.my', namespace='my')),
     url(r'^list/', include('events.urls.cal', namespace='cal')),
+    url(r'^email/', include('emails.urls', namespace='emails')),
     url(r'', include('accounts.urls', namespace='accounts')),
 
     # 'MY' {{{
@@ -64,10 +65,6 @@ urlpatterns = [
     # }}}
 
     # emails
-    url(r'^email/announce/(?P<slug>[-0-9a-f]+)/$', MeetingAnnounceView.as_view(),
-        name="email-view-announce"),
-    url(r'^email/announcecc/(?P<slug>[-0-9a-f]+)/$', MeetingAnnounceCCView.as_view(),
-        name="email-view-announce-cc"),
 
     # special urls
     url(r'^status/$', data.views.status),

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -125,9 +125,6 @@ urlpatterns = [
     # }}}
 
     # events {{{
-    url(r'^db/events/mk/$', 'events.views.mkedrm.eventnew', name="event-new"),
-    url(r'^db/events/edit/(?P<id>[0-9a-f]+)/$', 'events.views.mkedrm.eventnew',
-        name="event-edit"),
     url(r'^db/events/approve/(?P<id>[0-9a-f]+)/$', 'events.views.flow.approval',
         name="event-approve"),
     url(r'^db/events/deny/(?P<id>[0-9a-f]+)/$', 'events.views.flow.denial', name="event-deny"),

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -125,8 +125,6 @@ urlpatterns = [
     # }}}
 
     # events {{{
-    url(r'^db/events/review/(?P<id>[0-9a-f]+)/$', 'events.views.flow.review',
-        name="event-review"),
     url(r'^db/events/review/(?P<id>[0-9a-f]+)/remind/(?P<uid>[0-9a-f]+)/$',
         'events.views.flow.reviewremind', name="event-review-remind"),
     url(r'^db/events/close/(?P<id>[0-9a-f]+)/$', 'events.views.flow.close', name="event-close"),

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -47,8 +47,6 @@ urlpatterns = [
     url(r'', include('accounts.urls', namespace='accounts')),
 
     # 'MY' {{{
-    url(r'^my/events/(?P<eventid>[0-9]+)/files/$', 'events.views.my.eventfiles',
-        name="my-eventfiles"),
     url(r'^my/events/(?P<eventid>[0-9]+)/report/$', 'events.views.my.ccreport', name="my-ccreport"),
     url(r'^my/events/(?P<eventid>[0-9]+)/hours/$', 'events.views.my.hours_list', name="my-cchours"),
     url(r'^my/events/(?P<eventid>[0-9]+)/hours/bulk/$', 'events.views.my.hours_bulk',

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -125,7 +125,6 @@ urlpatterns = [
     # }}}
 
     # events {{{
-    url(r'^db/events/reopen/(?P<id>[0-9a-f]+)/$', 'events.views.flow.reopen', name="event-reopen"),
     url(r'^db/events/view/(?P<id>[0-9]+)/billing/pdf/$', 'pdfs.views.generate_event_bill_pdf',
         name="events-pdf-bill"),
     url(r'^db/events/view/(?P<event>[0-9]+)/billing/mk/$', BillingCreate.as_view(),

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -125,19 +125,12 @@ urlpatterns = [
     # }}}
 
     # events {{{
-    url(r'^db/events/view/(?P<id>[0-9]+)/billing/pdf/$', 'pdfs.views.generate_event_bill_pdf',
-        name="events-pdf-bill"),
     url(r'^db/events/view/(?P<event>[0-9]+)/billing/mk/$', BillingCreate.as_view(),
         name="event-mkbilling"),
     url(r'^db/events/view/(?P<event>[0-9]+)/billing/update/(?P<pk>[0-9]+)/$',
         BillingUpdate.as_view(), name="event-updbilling"),
     url(r'^db/events/view/(?P<event>[0-9]+)/billing/rm/(?P<pk>[0-9]+)/$',
         BillingDelete.as_view(), name="event-rmbilling"),
-    url(r'^db/events/view/(?P<event>[0-9]+)/report/mk/$', CCRCreate.as_view(), name="event-mkccr"),
-    url(r'^db/events/view/(?P<event>[0-9]+)/report/update/(?P<pk>[0-9]+)/$', CCRUpdate.as_view(),
-        name="event-updccr"),
-    url(r'^db/events/view/(?P<event>[0-9]+)/report/rm/(?P<pk>[0-9]+)/$', CCRDelete.as_view(),
-        name="event-rmccr"),
     url(r'^db/events/crew/(?P<id>[0-9a-f]+)/$', 'events.views.flow.assigncrew'),
     url(r'^db/events/rmcrew/(?P<id>[0-9a-f]+)/(?P<user>[0-9a-f]+)/$',
         'events.views.flow.rmcrew'),

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -125,7 +125,6 @@ urlpatterns = [
     # }}}
 
     # events {{{
-    url(r'^db/events/close/(?P<id>[0-9a-f]+)/$', 'events.views.flow.close', name="event-close"),
     url(r'^db/events/cancel/(?P<id>[0-9a-f]+)/$', 'events.views.flow.cancel', name="event-cancel"),
     url(r'^db/events/reopen/(?P<id>[0-9a-f]+)/$', 'events.views.flow.reopen', name="event-reopen"),
     url(r'^db/events/view/(?P<id>[0-9]+)/billing/pdf/$', 'pdfs.views.generate_event_bill_pdf',

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -1,6 +1,5 @@
 import debug_toolbar
 import django.contrib.auth.views
-import django_cas_ng.views
 import permission
 from ajax_select import urls as ajax_select_urls
 from django.conf import settings
@@ -10,8 +9,6 @@ from django.contrib.auth.decorators import login_required
 from django.views.generic.base import RedirectView
 
 import data.views
-from accounts.forms import LoginForm
-from accounts.views import smart_login
 from emails.views import MeetingAnnounceCCView, MeetingAnnounceView
 from events.cal import EventFeed, FullEventFeed, LightEventFeed, cal_json
 from events.forms import named_event_forms
@@ -64,42 +61,6 @@ urlpatterns = [
     url(r'^db/events/', include('events.urls.events', namespace='events')),
     url(r'^my/', include('events.urls.my', namespace='my')),
     url(r'', include('accounts.urls', namespace='accounts')),
-
-    # AUTHENTICATION {{{
-
-    # use the nice redirector for login
-    url(r'^login/$', smart_login, name="login"),
-
-    # best use CAS for logout, since it's guaranteed to log the user out
-    #  (without immediately signing them back in)
-    url(r'^logout/$', django_cas_ng.views.logout, name="logout"),
-
-    url(r'^cas/login/$', django_cas_ng.views.login, name="cas-explicit-login"),
-    url(r'^cas/logout/$', django_cas_ng.views.logout, name="cas-logout"),
-    # maybe we do
-    url(r'^local/login/$', django.contrib.auth.views.login,
-        {'template_name': 'registration/login.html',
-         'authentication_form': LoginForm},
-        name="local-login"),
-    url(r'^local/logout/$', django.contrib.auth.views.logout,
-        {'template_name': 'registration/logout.html'},
-        name="local-logout"),
-
-    url(r'^local/reset/$', django.contrib.auth.views.password_reset,
-        {'template_name': 'registration/reset_password.html',
-         'from_email': settings.DEFAULT_FROM_ADDR},
-        name='password_reset'),
-    url(r'^local/reset/confirm/(?P<uidb64>[0-9A-Za-z]+)-(?P<token>.+)/$',
-        django.contrib.auth.views.password_reset_confirm,
-        {'template_name': 'registration/reset_password_form.html'},
-        name='password_reset_confirm'),
-    url(r'^local/reset/sent/$', django.contrib.auth.views.password_reset_done,
-        {'template_name': 'registration/reset_password_sent.html'},
-        name='password_reset_done'),
-    url(r'^local/reset/done/$', django.contrib.auth.views.password_reset_complete,
-        {'template_name': 'registration/reset_password_finished.html'},
-        name='password_reset_complete'),
-    # }}}
 
     # 'MY' {{{
     url(r'^my/orgs/transfer/(?P<id>[0-9]+)/$', 'events.views.orgs.org_mkxfer', name="my-orgs-xfer"),

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -15,8 +15,7 @@ from accounts.views import smart_login
 from emails.views import MeetingAnnounceCCView, MeetingAnnounceView
 from events.cal import EventFeed, FullEventFeed, LightEventFeed, cal_json
 from events.forms import named_event_forms
-from events.views.flow import (BillingCreate, BillingDelete, BillingUpdate,
-                               CCRCreate, CCRDelete, CCRUpdate)
+from events.views.flow import CCRCreate, CCRDelete, CCRUpdate
 from events.views.indices import admin as db_home
 from events.views.indices import event_search
 from events.views.list import public_facing
@@ -125,12 +124,6 @@ urlpatterns = [
     # }}}
 
     # events {{{
-    url(r'^db/events/view/(?P<event>[0-9]+)/billing/mk/$', BillingCreate.as_view(),
-        name="event-mkbilling"),
-    url(r'^db/events/view/(?P<event>[0-9]+)/billing/update/(?P<pk>[0-9]+)/$',
-        BillingUpdate.as_view(), name="event-updbilling"),
-    url(r'^db/events/view/(?P<event>[0-9]+)/billing/rm/(?P<pk>[0-9]+)/$',
-        BillingDelete.as_view(), name="event-rmbilling"),
     url(r'^db/events/crew/(?P<id>[0-9a-f]+)/$', 'events.views.flow.assigncrew'),
     url(r'^db/events/rmcrew/(?P<id>[0-9a-f]+)/(?P<user>[0-9a-f]+)/$',
         'events.views.flow.rmcrew'),

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -47,7 +47,6 @@ urlpatterns = [
     url(r'', include('accounts.urls', namespace='accounts')),
 
     # 'MY' {{{
-    url(r'^my/events/$', 'events.views.my.myevents', name="my-events"),
     url(r'^my/events/(?P<eventid>[0-9]+)/files/$', 'events.views.my.eventfiles',
         name="my-eventfiles"),
     url(r'^my/events/(?P<eventid>[0-9]+)/report/$', 'events.views.my.ccreport', name="my-ccreport"),

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -127,8 +127,6 @@ urlpatterns = [
     # }}}
 
     # events {{{
-    url(r'^db/events/view/(?P<id>[0-9a-f]+)/$', 'events.views.flow.viewevent',
-        name="events-detail"),
     url(r'^db/events/view/(?P<id>[0-9a-f]+)/pdf/$', 'pdfs.views.generate_event_pdf',
         name="events-pdf"),
     url(r'^db/events/pdf/(?P<ids>\d+(,\d+)*)/$', 'pdfs.views.generate_event_pdf_multi',

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -124,8 +124,6 @@ urlpatterns = [
     # }}}
 
     # events {{{
-    url(r'^db/events/attachments/(?P<id>[0-9a-f]+)/$', 'events.views.flow.assignattach',
-        name="eventattachments"),
     url(r'^db/events/extras/(?P<id>[0-9a-f]+)/$', 'events.views.flow.extras',
         name="eventextras"),
     url(r'^db/events/oneoff/(?P<id>[0-9a-f]+)/$', 'events.views.flow.oneoff',

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -125,9 +125,6 @@ urlpatterns = [
     # }}}
 
     # events {{{
-    url(r'^db/events/approve/(?P<id>[0-9a-f]+)/$', 'events.views.flow.approval',
-        name="event-approve"),
-    url(r'^db/events/deny/(?P<id>[0-9a-f]+)/$', 'events.views.flow.denial', name="event-deny"),
     url(r'^db/events/review/(?P<id>[0-9a-f]+)/$', 'events.views.flow.review',
         name="event-review"),
     url(r'^db/events/review/(?P<id>[0-9a-f]+)/remind/(?P<uid>[0-9a-f]+)/$',

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -61,10 +61,6 @@ urlpatterns = [
     # emails
 
     # special urls
-    url(r'^status/$', data.views.status),
-    url(r'^db/accesslog/$', data.views.access_log, name="access-log"),
-    url(r'^NOTOUCHING/$', data.views.fuckoffkitty),
-    url(r'^lnldb/fuckoffkitty/$', RedirectView.as_view(url="/NOTOUCHING/", permanent=False)),
     url(r'^db/$', db_home, name="db"),
     url(r'^(?P<slug>[-\w]+)/$', view_page),
     url(r'^db/oldsearch$', event_search, name="events-search"),

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -123,13 +123,6 @@ urlpatterns = [
     url(r'^my/events/(?P<eventid>[0-9]+)/repeat/$', 'events.views.my.myworepeat', name="my-repeat"),
     # }}}
 
-    # events {{{
-    url(r'^db/events/extras/(?P<id>[0-9a-f]+)/$', 'events.views.flow.extras',
-        name="eventextras"),
-    url(r'^db/events/oneoff/(?P<id>[0-9a-f]+)/$', 'events.views.flow.oneoff',
-        name="eventoneoff"),
-    # }}}
-
     # projection {{{
     url(r'^db/projection/list/$', 'projection.views.plist_detail',
         name="projection-list-detail"),

--- a/lnldb/urls.py
+++ b/lnldb/urls.py
@@ -16,8 +16,6 @@ from events.views.indices import admin as db_home
 from events.views.indices import event_search
 from events.views.list import public_facing
 from pages.views import page as view_page
-from projection.views import (BulkUpdateView, ProjectionCreate,
-                              ProjectionistDelete)
 
 admin.autodiscover()
 permission.autodiscover()
@@ -42,6 +40,7 @@ urlpatterns = [
     url(r'^db/meetings/', include('meetings.urls', namespace='meetings')),
     url(r'^db/clients/', include('events.urls.orgs', namespace='orgs')),
     url(r'^db/inventory/', include('inventory.urls', namespace='inventory')),
+    url(r'^db/projection/', include('projection.urls', namespace='projection')),
     url(r'^db/events/', include('events.urls.events', namespace='events')),
     url(r'^workorder/', include('events.urls.wizard', namespace='wizard')),
     url(r'^my/', include('events.urls.my', namespace='my')),
@@ -63,23 +62,6 @@ urlpatterns = [
     url(r'^my/events/(?P<eventid>[0-9]+)/hours/(?P<userid>[0-9]+)$', 'events.views.my.hours_edit',
         name="my-cchours-edit"),
     url(r'^my/events/(?P<eventid>[0-9]+)/repeat/$', 'events.views.my.myworepeat', name="my-repeat"),
-    # }}}
-
-    # projection {{{
-    url(r'^db/projection/list/$', 'projection.views.plist_detail',
-        name="projection-list-detail"),
-    url(r'^db/projection/list/other/$', 'projection.views.plist', name="projection-list"),
-    url(r'^db/projection/bulk/$', BulkUpdateView.as_view(), name="projection-bulk-update"),
-    url(r'^db/projection/update/(?P<id>[0-9a-f]+)/$', "projection.views.projection_update",
-        name="projection-update"),
-    url(r'^db/projection/rm/(?P<pk>[0-9a-f]+)/$', ProjectionistDelete.as_view(),
-        name="projection-delete"),
-    url(r'^db/projection/mk/$', ProjectionCreate.as_view(), name="projection-create"),
-    url(r'^db/projection/list/detail/pdf/$', 'pdfs.views.generate_projection_pdf',
-        name="proj-pdf-multi"),
-
-    url(r'^db/projection/bulkevents/$', 'projection.views.bulk_projection',
-        name="projection-bulk2"),
     # }}}
 
     # event lists {{{

--- a/meetings/forms.py
+++ b/meetings/forms.py
@@ -89,7 +89,7 @@ class MtgAttachmentEditForm(forms.ModelForm):
         super(MtgAttachmentEditForm, self).__init__(*args, **kwargs)
         self.helper.add_input(Button('delete', 'Delete',
                                      onClick='window.location.href="{}"'
-                                     .format(reverse('meetings.views.rm_att',
+                                     .format(reverse('meetings:att-rm',
                                                      args=(self.instance.meeting.pk, self.instance.pk))),
                                      css_class='btn-danger'))
 

--- a/pdfs/tests/test_views.py
+++ b/pdfs/tests/test_views.py
@@ -8,6 +8,7 @@ class PdfViewTest(TestCase):
     """
     The simplest cases. Just measures if the pdf generators return successfully.
     """
+    # TODO: test projection pdfs
 
     def setUp(self):
         self.e = EventFactory.create(event_name="Test Event")

--- a/pdfs/tests/test_views.py
+++ b/pdfs/tests/test_views.py
@@ -20,11 +20,11 @@ class PdfViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_pdf_bill(self):
-        response = self.client.get(reverse('events-pdf-bill', args=[self.e.pk]))
+        response = self.client.get(reverse("events:pdf-bill", args=[self.e.pk]))
         self.assertEqual(response.status_code, 200)
         self.e2.reviewed = True
         self.e2.save()
-        response = self.client.get(reverse('events-pdf-bill', args=[self.e2.pk]))
+        response = self.client.get(reverse("events:pdf-bill", args=[self.e2.pk]))
         self.assertEqual(response.status_code, 200)
 
     def test_pdf_multi(self):

--- a/pdfs/tests/test_views.py
+++ b/pdfs/tests/test_views.py
@@ -16,7 +16,7 @@ class PdfViewTest(TestCase):
         self.client.login(username=self.user.username, password='123')
 
     def test_pdf(self):
-        response = self.client.get(reverse('events-pdf', args=[self.e.pk]))
+        response = self.client.get(reverse('events:pdf', args=[self.e.pk]))
         self.assertEqual(response.status_code, 200)
 
     def test_pdf_bill(self):
@@ -28,5 +28,5 @@ class PdfViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_pdf_multi(self):
-        response = self.client.get(reverse('events-pdf-multi', args=["%s,%s" % (self.e.pk, self.e2.pk)]))
+        response = self.client.get(reverse('events:pdf-multi', args=["%s,%s" % (self.e.pk, self.e2.pk)]))
         self.assertEqual(response.status_code, 200)

--- a/pdfs/tests/test_views.py
+++ b/pdfs/tests/test_views.py
@@ -20,11 +20,11 @@ class PdfViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_pdf_bill(self):
-        response = self.client.get(reverse("events:pdf-bill", args=[self.e.pk]))
+        response = self.client.get(reverse("events:bills:pdf", args=[self.e.pk]))
         self.assertEqual(response.status_code, 200)
         self.e2.reviewed = True
         self.e2.save()
-        response = self.client.get(reverse("events:pdf-bill", args=[self.e2.pk]))
+        response = self.client.get(reverse("events:bills:pdf", args=[self.e2.pk]))
         self.assertEqual(response.status_code, 200)
 
     def test_pdf_multi(self):

--- a/pdfs/views.py
+++ b/pdfs/views.py
@@ -103,10 +103,10 @@ def currency(dollars):
 
 
 @login_required
-def generate_event_bill_pdf(request, id):
+def generate_event_bill_pdf(request, event):
     # Prepare context
     data = {}
-    event = get_object_or_404(Event, pk=id)
+    event = get_object_or_404(Event, pk=event)
     data['event'] = event
     cats = Category.objects.all()
     extras = {}

--- a/pdfs/views.py
+++ b/pdfs/views.py
@@ -3,7 +3,7 @@ import os
 from io import BytesIO
 
 from django.conf import settings
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.contrib.staticfiles import finders
 from django.http import HttpResponse
@@ -42,7 +42,8 @@ def link_callback(uri, rel):
         raise Exception('media URI must start with %s or %s' % (surl, murl))
     return path
 
-
+@login_required
+@permission_required("projection.view_pits", raise_exception=True)
 def generate_projection_pdf(request):
     data = {}
     # prepare data

--- a/projection/tests.py
+++ b/projection/tests.py
@@ -1,0 +1,182 @@
+from django.core.urlresolvers import reverse
+from data.tests.util import ViewTestCase
+from django.contrib.auth.models import Permission
+from . import models
+
+
+class ProjViewTest(ViewTestCase):
+    def test_plist(self):
+        # make sure normies can't see this
+        self.assertOk(self.client.get(reverse("projection:list")), 403)
+
+        permission = Permission.objects.get(codename='view_pits')
+        self.user.user_permissions.add(permission)
+
+        # blank
+        self.assertOk(self.client.get(reverse("projection:list")))
+
+        proj = models.Projectionist.objects.create(user=self.user)
+        proj.save()
+
+        # with people
+        self.assertOk(self.client.get(reverse("projection:list")))
+
+    def test_plist_detail(self):
+        # make sure normies can't see this
+        self.assertOk(self.client.get(reverse("projection:list")), 403)
+
+        permission = Permission.objects.get(codename='view_pits')
+        self.user.user_permissions.add(permission)
+        self.assertOk(self.client.get(reverse("projection:grid")))
+
+        # blank
+        proj = models.Projectionist.objects.create(user=self.user)
+        proj.save()
+
+        # with people
+        self.assertOk(self.client.get(reverse("projection:list")))
+
+    def test_pdf(self):
+        # make sure normies can't see this
+        self.assertOk(self.client.get(reverse("projection:pdf")), 403)
+
+        permission = Permission.objects.get(codename='view_pits')
+        self.user.user_permissions.add(permission)
+
+        # blank
+        self.assertOk(self.client.get(reverse("projection:pdf")))
+
+        proj = models.Projectionist.objects.create(user=self.user)
+        proj.save()
+
+        # with people
+        self.assertOk(self.client.get(reverse("projection:list")))
+
+    def test_create(self):
+        valid_form_data = {
+            'user_text': "",
+            'user': self.user.pk,
+            'license_number': "",
+            'license_expiry': "",
+            'pitinstances-TOTAL_FORMS': 1,
+            'pitinstances-INITIAL_FORMS': 0,
+            'pitinstances-MIN_NUM_FORMS': 0,
+            'pitinstances-MAX_NUM_FORMS': 1000,
+            'pitinstances-0-id': "",
+            'pitinstances-0-pit_level': "",
+            'pitinstances-0-created_on_0': "",
+            'pitinstances-0-created_on_1': "",
+            'pitinstances-0-valid': "on",
+            'submit': 'Save changes'
+        }
+
+        # make sure normies can't see this
+        self.assertOk(self.client.get(reverse("projection:new")), 403)
+
+        # give ourselves permissions
+        permission = Permission.objects.get(codename='edit_pits')
+        self.user.user_permissions.add(permission)
+
+        # we can view the form now!
+        self.assertOk(self.client.get(reverse("projection:new")))
+
+        # submitting with invalid data redisplays form
+        self.assertOk(self.client.post(reverse("projection:new")))
+
+        # needed for the page we redirect to
+        permission = Permission.objects.get(codename='view_pits')
+        self.user.user_permissions.add(permission)
+
+        # Get a redirect on valid data
+        resp = self.client.post(reverse("projection:new"), valid_form_data)
+        self.assertRedirects(resp, reverse("projection:grid"))
+
+        # check it was actually created
+        self.assertTrue(models.Projectionist.objects.filter(user=self.user).exists())
+
+    def test_delete(self):
+        # make an object for us
+        proj = models.Projectionist.objects.create(user=self.user)
+        proj.save()
+
+        # make sure normies can't see this
+        self.assertOk(self.client.get(reverse("projection:remove", args=[self.user.pk])), 403)
+
+        # give ourselves permissions
+        permission = Permission.objects.get(codename='edit_pits')
+        self.user.user_permissions.add(permission)
+
+        # we can view the form now!
+        self.assertOk(self.client.get(reverse("projection:remove", args=[self.user.pk])))
+
+        # needed for the page we redirect to
+        permission = Permission.objects.get(codename='view_pits')
+        self.user.user_permissions.add(permission)
+
+        # Get a redirect on valid data
+        self.assertRedirects(self.client.post(reverse("projection:remove", args=[self.user.pk])),
+                             reverse("projection:grid"))
+
+        # check it was actually deleted
+        self.assertFalse(models.Projectionist.objects.filter(user=self.user).exists())
+
+    def test_edit(self):
+        # make an object for us
+        proj = models.Projectionist.objects.create(user=self.user)
+        proj.save()
+
+        valid_form_data = {
+            'main-license_number': "12345",
+            'main-license_expiry': "",
+            'nested-TOTAL_FORMS': 1,
+            'nested-INITIAL_FORMS': 0,
+            'nested-MIN_NUM_FORMS': 0,
+            'nested-MAX_NUM_FORMS': 1000,
+            'nested-0-id': "",
+            'nested-0-pit_level': "",
+            'nested-0-created_on_0': "",
+            'nested-0-created_on_1': "",
+            'nested-0-valid': "on",
+            'submit': 'Save changes'
+        }
+
+        # make sure normies can't see this
+        self.assertOk(self.client.get(reverse("projection:edit", args=[proj.pk])), 403)
+
+        # give ourselves permissions
+        permission = Permission.objects.get(codename='edit_pits')
+        self.user.user_permissions.add(permission)
+        # needed for the page we redirect to
+        permission = Permission.objects.get(codename='view_pits')
+        self.user.user_permissions.add(permission)
+
+        # we can view the form now!
+        self.assertOk(self.client.get(reverse("projection:edit", args=[proj.pk])))
+
+        # Get a redirect on valid data
+        resp = self.client.post(reverse("projection:edit", args=[proj.pk]), valid_form_data)
+        self.assertRedirects(resp, reverse("projection:grid"))
+
+        # check it was actually changed
+        self.assertEqual(models.Projectionist.objects.get(user=self.user).license_number, '12345')
+        # TODO: Check pitinstances
+
+    def test_bulk_edit(self):
+        # make sure normies can't see this
+        self.assertOk(self.client.get(reverse("projection:bulk-edit")), 403)
+
+        permission = Permission.objects.get(codename='edit_pits')
+        self.user.user_permissions.add(permission)
+
+        self.assertOk(self.client.get(reverse("projection:bulk-edit")))
+        # TODO: the rest of the test
+
+    def test_bulk_movies(self):
+        # make sure normies can't see this
+        self.assertOk(self.client.get(reverse("projection:add-movies")), 403)
+
+        permission = Permission.objects.get(codename='add_bulk_events')
+        self.user.user_permissions.add(permission)
+        self.assertOk(self.client.get(reverse("projection:add-movies")))
+
+        # TODO: the rest of the test

--- a/projection/urls.py
+++ b/projection/urls.py
@@ -1,0 +1,19 @@
+from django.conf.urls import url
+
+from pdfs import views as pdf_views
+
+from . import views
+
+urlpatterns = [
+    url(r'^list/$', views.plist_detail, name="grid"),
+    url(r'^list/other/$', views.plist, name="list"),
+    url(r'^list/detail/pdf/$', pdf_views.generate_projection_pdf,
+        name="pdf"),
+
+    url(r'^mk/$', views.ProjectionCreate.as_view(), name="new"),
+    url(r'^bulk/$', views.BulkUpdateView.as_view(), name="bulk-edit"),
+    url(r'^update/(?P<id>[0-9a-f]+)/$', views.projection_update, name="edit"),
+    url(r'^rm/(?P<pk>[0-9a-f]+)/$', views.ProjectionistDelete.as_view(), name="remove"),
+
+    url(r'^bulkevents/$', views.bulk_projection, name="add-movies"),
+]

--- a/projection/views.py
+++ b/projection/views.py
@@ -64,7 +64,7 @@ def projection_update(request, id):
         if form.is_valid() and formset.is_valid():
             form.save()
             formset.save()
-            return HttpResponseRedirect(reverse("projection-list-detail"))
+            return HttpResponseRedirect(reverse("projection:grid"))
         else:
             context['form'] = form
             context['formset'] = formset
@@ -109,11 +109,11 @@ class ProjectionCreate(LoginRequiredMixin, HasPermMixin, CreateView):
     model = Projectionist
     template_name = "form_crispy_projection.html"
     form_class = ProjectionistForm
-    # success_url = reverse("projection-list")
+    # success_url = reverse("projection:list")
 
     @property
     def success_url(self):
-        return reverse('projection-list-detail')
+        return reverse("projection:grid")
 
 
 class BulkUpdateView(LoginRequiredMixin, HasPermMixin, FormView):
@@ -123,7 +123,7 @@ class BulkUpdateView(LoginRequiredMixin, HasPermMixin, FormView):
 
     @property
     def success_url(self):
-        return reverse('projection-list-detail')
+        return reverse("projection:grid")
 
     def form_valid(self, form):
         # This method is called when valid form data has been POSTed.
@@ -139,7 +139,7 @@ class ProjectionistDelete(LoginRequiredMixin, HasPermMixin, DeleteView):
     perms = 'projection.edit_pits'
 
     def get_success_url(self):
-        return reverse("projection-list-detail")
+        return reverse("projection:grid")
 
 
 def get_saturdays_for_range(date_1, date_2):

--- a/site_tmpl/access_log.html
+++ b/site_tmpl/access_log.html
@@ -10,7 +10,7 @@
     </tr>
     {% for access in accesses %}
             <tr>
-                <td><a href="{% url "projection-update" access.user.id %}">{{ access.user }}</a></td>
+                <td><a href="{% url "projection:edit" access.user.id %}">{{ access.user }}</a></td>
                 <td>
                     {{ access.user_ip }}
                 </td>

--- a/site_tmpl/admin.html
+++ b/site_tmpl/admin.html
@@ -26,7 +26,7 @@
                 </tr>
                 {% for event in events %}
                         <tr>
-                            <td><a href="{% url "events.views.flow.viewevent" event.id %}">{{event.event_name}}</a></td>
+                            <td><a href="{% url "events:detail" event.id %}">{{event.event_name}}</a></td>
                             <td>{{event.datetime_start}}</td>
                             <td>{{event.datetime_end}}</td>
                             <td>

--- a/site_tmpl/admin.nav.html
+++ b/site_tmpl/admin.nav.html
@@ -151,13 +151,13 @@
                         </a>
                         <ul class="dropdown-menu">
                             {% permission request.user has 'projection.view_pits' %}
-                                <li><a href="{% url "projection.views.plist_detail" %}">View Projectionists</a></li>
+                                <li><a href="{% url "projection:grid" %}">View Projectionists</a></li>
                             {% endpermission %}
                             {% permission request.user has 'projection.edit_pits' %}
-                                <li><a href="{% url "projection-bulk-update" %}">Bulk Update Projectionists</a></li>
+                                <li><a href="{% url "projection:bulk-edit" %}">Bulk Update Projectionists</a></li>
                             {% endpermission %}
                             {% permission request.user has 'projection.add_bulk_events' %}
-                                <li><a href="{% url "projection-bulk2" %}">Bulk Add Movies</a></li>
+                                <li><a href="{% url "projection:add-movies" %}">Bulk Add Movies</a></li>
                             {% endpermission %}
                         </ul>
                     </li>

--- a/site_tmpl/admin.nav.html
+++ b/site_tmpl/admin.nav.html
@@ -105,10 +105,6 @@
                             <li class="divider"></li>
                             <li><a href="{% url "accounts:add" %}">Add User</a></li>
                         {% endpermission %}
-                        {% permission request.user has 'events.event_view_granular' %}
-                            <li class="divider"></li>
-                            <li><a href="{% url "access-log" %}">Access Log</a>
-                        {% endpermission %}
                     </ul>
                 </li>
                 {% endpermission %}

--- a/site_tmpl/admin.nav.html
+++ b/site_tmpl/admin.nav.html
@@ -11,7 +11,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-                <a class="navbar-brand" href="{% url "events.views.indices.admin" %}">LNLDB</a>
+                <a class="navbar-brand" href="{% url "home" %}">LNLDB</a>
         </div>
 
             <div class="collapse navbar-collapse" id="db-navbar-collapse-1">

--- a/site_tmpl/admin.nav.html
+++ b/site_tmpl/admin.nav.html
@@ -32,7 +32,7 @@
                     </a>
                     <ul class="dropdown-menu">
                         <li><a href="{% url 'events.views.my.myevents' %}">My Events</a></li>
-                        <li><a href="{% url 'event' %}">Event Wizard</a></li>
+                        <li><a href="{% url 'wizard:start' %}">Event Wizard</a></li>
 
                         {% permission request.user has 'events.add_raw_event' %}
                         <li><a href="{% url "events:new" %}">Add Event</a></li>

--- a/site_tmpl/admin.nav.html
+++ b/site_tmpl/admin.nav.html
@@ -35,7 +35,7 @@
                         <li><a href="{% url 'event' %}">Event Wizard</a></li>
 
                         {% permission request.user has 'events.add_raw_event' %}
-                        <li><a href="{% url "events.views.mkedrm.eventnew" %}">Add Event</a></li>
+                        <li><a href="{% url "events:new" %}">Add Event</a></li>
                         {% endpermission %}
 
                         {% permission request.user has 'events.view_event' %}

--- a/site_tmpl/admin.nav.html
+++ b/site_tmpl/admin.nav.html
@@ -31,7 +31,7 @@
                         Events <b class="caret"></b>
                     </a>
                     <ul class="dropdown-menu">
-                        <li><a href="{% url 'events.views.my.myevents' %}">My Events</a></li>
+                        <li><a href="{% url "my:events" %}">My Events</a></li>
                         <li><a href="{% url 'wizard:start' %}">Event Wizard</a></li>
 
                         {% permission request.user has 'events.add_raw_event' %}

--- a/site_tmpl/admin.nav.html
+++ b/site_tmpl/admin.nav.html
@@ -20,9 +20,9 @@
                     Logged in as <a href="{% url  "accounts:detail" request.user.pk %}"
                                     class="navbar-link">{{ request.user }}</a>
                 &middot;
-                <a href="{% url 'logout' %}">Log Out</a>
+                <a href="{% url "accounts:logout" %}">Log Out</a>
                 {% else %}
-                    <a href="{% url 'login' %}">Log In</a>
+                    <a href="{% url "accounts:login" %}">Log In</a>
                 {% endif %}
             </p>
             <ul class="nav navbar-nav">

--- a/site_tmpl/base.html
+++ b/site_tmpl/base.html
@@ -162,7 +162,7 @@
         </div>
 
       <footer>
-          <p>&copy; WPI Lens and Lights &middot; <a href="{% url 'list' %}">Want to get involved?</a>
+          <p>&copy; WPI Lens and Lights &middot; <a href="{% url "cal:list" %}">Want to get involved?</a>
         
         </p>
         <p>Generated {% now "N d Y, P e" %}; version {{ GIT_RELEASE }}</p>

--- a/site_tmpl/base_pages.html
+++ b/site_tmpl/base_pages.html
@@ -247,13 +247,13 @@
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                     </button>
-                    <a class="navbar-brand" href="{% url "pages.views.page" "index" %}">Lens and Lights</a>
+                    <a class="navbar-brand" href="{% url "page" "index" %}">Lens and Lights</a>
                 </div>
                 <div class="navbar-collapse collapse">
                     <ul class="nav navbar-nav">
                         {% for nav in navs.navs %}
                             <li {% if nav == page %} class="active" {% endif %}><a
-                                    href="{% url "pages.views.page" nav.slug %}">{{ nav.title }}</a></li>
+                                    href="{% url "page" nav.slug %}">{{ nav.title }}</a></li>
                         {% endfor %}
                         <li><a href="#PriceModal" data-toggle="modal">Price List</a></li>
                         <li><a href="{% url 'wizard:start' %}">Workorder</a></li>
@@ -278,12 +278,12 @@
             <span class="glyphicon glyphicon-bar"></span>
             <span class="glyphicon glyphicon-bar"></span>
           </a>
-          <a class="navbar-brand" href="{% url "pages.views.page" "index" %}">Lens and Lights</a>
+          <a class="navbar-brand" href="{% url "page" "index" %}">Lens and Lights</a>
           <!-- Responsive Navbar Part 2: Place all navbar contents you want collapsed withing .navbar-collapse.collapse. -->
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
               {% for nav in navs.navs %}
-              <li {% if nav = page %} class="active" {% endif %}><a href="{% url "pages.views.page" nav.slug %}">{{ nav.title }}</a></li>
+              <li {% if nav = page %} class="active" {% endif %}><a href="{% url "page" nav.slug %}">{{ nav.title }}</a></li>
               {% endfor %}
               <li><a href="#PriceModal" data-toggle="modal">Price List</a></li>
               <li><a href="/workorder">Workorder</a></li>

--- a/site_tmpl/base_pages.html
+++ b/site_tmpl/base_pages.html
@@ -256,7 +256,7 @@
                                     href="{% url "pages.views.page" nav.slug %}">{{ nav.title }}</a></li>
                         {% endfor %}
                         <li><a href="#PriceModal" data-toggle="modal">Price List</a></li>
-                        <li><a href="{% url 'event' %}">Workorder</a></li>
+                        <li><a href="{% url 'wizard:start' %}">Workorder</a></li>
                         <li><a href="{% url "accounts:me" %}">My Account</a></li>
                     </ul>
                 </div>

--- a/site_tmpl/emails/email_transfer.html
+++ b/site_tmpl/emails/email_transfer.html
@@ -14,7 +14,7 @@
                 <div align="left" class="article-content">
                     
                     <p>Please Follow the link below in order to complete your organizational transfer.</p>
-                    <a href="{% url "my-orgs-acceptxfer" object.uuid.hex %}">{% url "my-orgs-acceptxfer" object.uuid.hex %}</a>
+                    <a href="{% url "my:org-accept" object.uuid.hex %}">{% url "my:org-accept" object.uuid.hex %}</a>
                 </div>
             </td>
         </tr>

--- a/site_tmpl/emails/email_transfer.txt
+++ b/site_tmpl/emails/email_transfer.txt
@@ -2,4 +2,4 @@ Organization Transfer Email
 
 Please Follow the link below in order to complete your organizational transfer.
 
-{% url "my-orgs-acceptxfer" object.uuid.hex %}
+{% url "my:org-accept" object.uuid.hex %}

--- a/site_tmpl/event_review.html
+++ b/site_tmpl/event_review.html
@@ -51,7 +51,7 @@
         <tr>
             <td>{{ crew.crew_chief.get_full_name }}</td>
             <td><a class="btn btn-warning btn-default btn-xs"
-                   href={% url "event-review-remind" id=event.id uid=crew.crew_chief.id %}>Remind</a></td>
+                   href={% url "events:remind" id=event.id uid=crew.crew_chief.id %}>Remind</a></td>
         </tr>
         {% endfor %}
         </table>

--- a/site_tmpl/events.html
+++ b/site_tmpl/events.html
@@ -110,7 +110,7 @@
                     {% for field in cols %}
                         {% if field.name == 'event_name' %}
                             <td class="event-name"><a
-                                    href="{% url "events.views.flow.viewevent" event.id %}">{{ event.event_name }}</a>
+                                    href="{% url "events:detail" event.id %}">{{ event.event_name }}</a>
                             </td>
 
                         {% elif field.name == 'org' %}

--- a/site_tmpl/events.html
+++ b/site_tmpl/events.html
@@ -163,7 +163,7 @@
                         {% elif field.name == 'tasks' %}
                             <td class="tasks">
                                 <span class="crewtask"><a
-                                        href="{% url "events.views.flow.assigncrew" event.id %}">Crew</a></span>
+                                        href="{% url "events:add-crew" event.id %}">Crew</a></span>
                             </td>
 
                         {% else %}

--- a/site_tmpl/events_public.html
+++ b/site_tmpl/events_public.html
@@ -2,7 +2,8 @@
 {% load bootstrap_calendar %}
 
 {% block extras %}
-{% bootstrap_calendar_js events_url="/list/json" %}
+{% url 'cal:api' as bootcal_endpoint %}
+{% bootstrap_calendar_js events_url=bootcal_endpoint %}
 {% bootstrap_calendar_css %}
 {% endblock %}
 
@@ -22,7 +23,7 @@
                             program (look for 'Add by URL' or 'Internet Calendar').</p>
                         <div class="input-group">
                             <input class="form-control" id="cal_url" type="text" readonly onclick="$(this).select();"
-                                   value="http{% if request.is_secure %}s{% endif %}://{% firstof request.META.HTTP_HOST 'lnl.wpi.edu' %}{% url 'public_cal_feed' %}" >
+                                   value="http{% if request.is_secure %}s{% endif %}://{% firstof request.META.HTTP_HOST 'lnl.wpi.edu' %}{% url "cal:feed" %}" >
                             <span class="input-group-btn">
                                 <button class="btn btn-default" type="button"
                                         onclick="$('#cal_url').select();document.execCommand('copy');">

--- a/site_tmpl/events_public.html
+++ b/site_tmpl/events_public.html
@@ -71,7 +71,7 @@
             </tr>
             {% for event in events %}
                     <tr id="{{event.id}}">
-                        <td><a href="{% url "events-detail" event.pk %}">{{event.event_name}}</a> - <b>{{ event.short_services }}</b></td> 
+                        <td><a href="{% url "events:detail" event.pk %}">{{event.event_name}}</a> - <b>{{ event.short_services }}</b></td> 
                         <td>{{event.location}} ({{event.location.building }})</td>
                         <td>
                             {% for cc in event.ccinstances.all|dictsort:"setup_start" %}

--- a/site_tmpl/events_search_results.html
+++ b/site_tmpl/events_search_results.html
@@ -40,7 +40,7 @@
             </tr>
             {% for event in events %}
                     <tr class="event-status-{{ event.status | slugify }}">
-                        <td class="event-name"><a href="{% url "events.views.flow.viewevent" event.id %}">{{event.event_name}}</a></td>
+                        <td class="event-name"><a href="{% url "events:detail" event.id %}">{{event.event_name}}</a></td>
                         <td class="event-start">{{event.datetime_start}}</td>
                         <td class="event-orgs">
                             {% for org in event.org.all %}

--- a/site_tmpl/events_search_results.html
+++ b/site_tmpl/events_search_results.html
@@ -76,7 +76,7 @@
                             {% if event.otherservices.count %} Y {% else %} N {% endif %}
                         </td>
                         <td class="tasks">
-                            <span class="crewtask"><a href="{% url "events.views.flow.assigncrew" event.id %}">Crew</a></span>
+                            <span class="crewtask"><a href="{% url "events:add-crew" event.id %}">Crew</a></span>
                             <input type="checkbox" class="hide eventselect" title="Select {{ event.event_name }}"
                                    value="{{ event.id }}">
                         </td>

--- a/site_tmpl/ext_orgs.html
+++ b/site_tmpl/ext_orgs.html
@@ -13,7 +13,7 @@
     {% for org in orgs %}
             <tr>
                 <td><a href="{% url 'my:org-edit' org.id %}">{{org}}</a></td>
-                <td><a href="{% url 'my-orgs-xfer' org.id %}">Transfer Ownership</a>
+                <td><a href="{% url "my:org-transfer" org.id %}">Transfer Ownership</a>
             </tr>
     {% empty %}
         <tr>

--- a/site_tmpl/form_crew_add.html
+++ b/site_tmpl/form_crew_add.html
@@ -11,7 +11,7 @@
                     {% for crew in event.crew.all %}
                     
                     <tr>
-                        <td> <a href="{% url "events.views.flow.rmcrew" event.id crew.id %}"><i class="glyphicon glyphicon-remove"></i></a>
+                        <td> <a href="{% url "events:remove-crew" event.id crew.id %}"><i class="glyphicon glyphicon-remove"></i></a>
                         <td> {{ crew.first_name }} {{crew.last_name}} </td>
                         
                     </tr>

--- a/site_tmpl/form_crew_chiefadd.html
+++ b/site_tmpl/form_crew_chiefadd.html
@@ -12,7 +12,7 @@
                     {% for crew in event.crew_chief.all %}
                     
                     <tr>
-                        <td> <a href="{% url "events.views.flow.rmcc" event.id crew.id %}"><i class="glyphicon glyphicon-remove"></i></a>
+                        <td> <a href="{% url "events:remove-chief" event.id crew.id %}"><i class="glyphicon glyphicon-remove"></i></a>
                         <td> {{ crew.first_name }} {{crew.last_name}} </td>
                         
                     </tr>

--- a/site_tmpl/form_crispy_bulk_projection_done.html
+++ b/site_tmpl/form_crispy_bulk_projection_done.html
@@ -8,7 +8,7 @@
             <ul>
             {% for event in result %}
                 <li>
-                    <a href="{% url "events.views.flow.viewevent" event.id %}">{{event.event_name}}</a>
+                    <a href="{% url "events:detail" event.id %}">{{event.event_name}}</a>
                 </li>
             {% empty %}
             No Events Added

--- a/site_tmpl/form_crispy_bulk_projection_entries.html
+++ b/site_tmpl/form_crispy_bulk_projection_entries.html
@@ -69,7 +69,7 @@
                 </table>
                 <div class="form-actions">
                     <input name="submit" value="Save changes" class="btn btn-primary" id="submit-id-save" type="submit"> 
-                    {% if pk %}<a class="btn btn-danger" href="{% url "projection-delete" pk %}">Delete This User</a> {% endif %}
+                    {% if pk %}<a class="btn btn-danger" href="{% url "projection:remove" pk %}">Delete This User</a> {% endif %}
                 </div>
             </form>
             

--- a/site_tmpl/form_crispy_projection.html
+++ b/site_tmpl/form_crispy_projection.html
@@ -38,7 +38,7 @@
                 </table>
                     <div class="form-actions">
                         <input name="submit" value="Save changes" class="btn btn-primary" id="submit-id-save" type="submit"> 
-                        {% if pk %}<a class="btn btn-danger" href="{% url "projection-delete" pk %}">Delete This User</a> {% endif %}
+                        {% if pk %}<a class="btn btn-danger" href="{% url "projection:remove" pk %}">Delete This User</a> {% endif %}
                     </div>
                 </form>
                 

--- a/site_tmpl/index.html
+++ b/site_tmpl/index.html
@@ -23,7 +23,7 @@
             {% if is_officer %}
             <div class="col-md-4">
                 <h2>Admin</h2>
-                <p><a class="btn btn-danger" href="{% url "events.views.indices.admin" %}">LN Admin&raquo;</a></p>
+                <p><a class="btn btn-danger" href="{% url "home" %}">LN Admin&raquo;</a></p>
             </div><!--/span-->
             {% endif %}
         </div><!--/row-->

--- a/site_tmpl/index.html
+++ b/site_tmpl/index.html
@@ -12,7 +12,7 @@
             <div {% if is_officer %}class="col-md-4" {% else %}class="col-md-6"{% endif %}>
                 <h2>Workorders</h2>
 
-                <p><a class="btn btn-primary" href="{% url 'event' %}">Submit A Workorder &raquo;</a></p>
+                <p><a class="btn btn-primary" href="{% url 'wizard:start' %}">Submit A Workorder &raquo;</a></p>
             </div><!--/span-->
 
             <div {% if is_officer %}class="col-md-4" {% else %}class="col-md-6"{% endif %}>

--- a/site_tmpl/meeting_view.html
+++ b/site_tmpl/meeting_view.html
@@ -177,7 +177,7 @@
                         </tr>
                         {% for e in events %}
                             <tr data-toggle="collapse" data-target="#entry{{e.id}}">
-                                <td><a href="{% url "events.views.flow.viewevent" e.id %}">{{ e.event_name }}</a></td>
+                                <td><a href="{% url "events:detail" e.id %}">{{ e.event_name }}</a></td>
                                 <td>
                                     {% if e.lighting %} {{ e.lighting.shortname }} {% endif %}
                                     {% if e.sound %} {{ e.sound.shortname }} {% endif %}
@@ -228,7 +228,7 @@
                         </tr>
                         {% for e in future %}
                             <tr data-toggle="collapse" data-target="#entry{{e.id}}">
-                                <td><a href="{% url "events.views.flow.viewevent" e.id %}">{{ e.event_name }}</a></td>
+                                <td><a href="{% url "events:detail" e.id %}">{{ e.event_name }}</a></td>
                                 <td>
                                     {% if e.lighting %} {{ e.lighting.shortname }} {% endif %}
                                     {% if e.sound %} {{ e.sound.shortname }} {% endif %}

--- a/site_tmpl/meeting_view.html
+++ b/site_tmpl/meeting_view.html
@@ -121,7 +121,7 @@
                                         {% endif %}
 
                                         <br/>
-                                        <a href="{% url "email-view-announce" announce.uuid %}" class="cm-webversion">View
+                                        <a href="{% url "emails:pre-meeting" announce.uuid %}" class="cm-webversion">View
                                             Online</a>
                                     </div>
                                 </div>
@@ -148,7 +148,7 @@
                                             {% endfor %}
                                         {% endif %}
 
-                                    <a href="{% url "email-view-announce-cc" announce.uuid %}" class="cm-webversion">View Online</a>
+                                    <a href="{% url "emails:post-meeting" announce.uuid %}" class="cm-webversion">View Online</a>
                                     </div>
                                 </div>
                             </div>

--- a/site_tmpl/my.html
+++ b/site_tmpl/my.html
@@ -32,7 +32,7 @@
         <div class="col-md-3">
             <img class="img-circle" src="{% static 'img/MyEvents.gif' %}"/>
             <h2> My Events </h2>
-            <a href="{% url "events.views.my.myevents" %}" class="btn btn-lg btn-primary">View Events</a>
+            <a href="{% url "my:events" %}" class="btn btn-lg btn-primary">View Events</a>
             
         </div>
         {% endif %}

--- a/site_tmpl/my.html
+++ b/site_tmpl/my.html
@@ -16,7 +16,7 @@
             <img class="img-circle" src="{% static 'img/WorkOrders.gif' %}"/>
             <h2> WorkOrders </h2>
             <div class="btn-group">
-                <a href="{% url 'event' %}" class="btn btn-lg btn-primary">New</a>
+                <a href="{% url 'wizard:start' %}" class="btn btn-lg btn-primary">New</a>
                 <a href="{% url "my:workorder" %}" class="btn btn-lg btn-primary">Previous</a>
             </div>
         </div>

--- a/site_tmpl/my.nav.html
+++ b/site_tmpl/my.nav.html
@@ -15,9 +15,9 @@
             <p class="navbar-text navbar-right">
             {% if user.is_authenticated %}
                 Logged in as <a href="#" class="navbar-link">{{ user }}</a> &middot;
-                <a href="{% url "logout" %}">Log Out</a>
+                <a href="{% url "accounts:logout" %}">Log Out</a>
             {% else %}
-                <a href="{% url 'login' %}"> Log In </a>
+                <a href="{% url "accounts:login" %}"> Log In </a>
             {% endif %}
             </p>
         </div>

--- a/site_tmpl/myevents.html
+++ b/site_tmpl/myevents.html
@@ -23,7 +23,7 @@
                     <td>{{ instance.event.location }}</td>
                     <td>
                         <div class="btn-group">
-                            <a class="btn btn-default" href="{% url 'my-events-pdf' instance.event.id %}">Workorder
+                            <a class="btn btn-default" href="{% url 'events:pdf' instance.event.id %}">Workorder
                                 PDF </a>
                             {% if instance.event.reports_editable %}
                                 <a class="btn btn-primary" href="{% url 'my-ccreport' instance.event.id %}">CC

--- a/site_tmpl/myevents.html
+++ b/site_tmpl/myevents.html
@@ -12,7 +12,7 @@
             </tr>
             {% for instance in ccinstances %}
                 <tr>
-                    <td><a href="{% url 'events-detail' instance.event.pk %}">{{ instance.event.event_name }}</a></td>
+                    <td><a href="{% url 'events:detail' instance.event.pk %}">{{ instance.event.event_name }}</a></td>
                     <td title="{{ instance.event.datetime_start }}">
                         {% if instance.event.datetime_start > now %}
                             {{ instance.event.datetime_start|timeuntil }} from now
@@ -55,7 +55,7 @@
         </tr>
         {% for instance in hours %}
                 <tr>
-                    <td><a href="{% url 'events-detail' instance.event.pk %}">{{ instance.event.event_name }}</a></td>
+                    <td><a href="{% url 'events:detail' instance.event.pk %}">{{ instance.event.event_name }}</a></td>
                     <td title="{{instance.event.datetime_start}}">
                         {% if instance.event.datetime_start > now %}
                             {{instance.event.datetime_start|timeuntil}} from now 
@@ -90,7 +90,7 @@
             </tr>
             {% for event in submitted_events %}
                     <tr>
-                        <td><a href="{% url 'events-detail' event.pk %}">{{ event.event_name }}</a></td>
+                        <td><a href="{% url 'events:detail' event.pk %}">{{ event.event_name }}</a></td>
                         <td title="{{event.datetime_end}}">
                             {% if event.datetime_end > now %}
                                 {{event.datetime_end|timeuntil}} from now 
@@ -120,7 +120,7 @@
                 </tr>
                 {% for event in org.event_set.all %}
                     <tr>
-                        <td><a href="{% url 'events-detail' event.pk %}">{{ event.event_name }}</a></td>
+                        <td><a href="{% url 'events:detail' event.pk %}">{{ event.event_name }}</a></td>
                         <td title="{{ event.datetime_end }}">
                             {% if event.datetime_end > now %}
                                 {{ event.datetime_end|timeuntil }} from now

--- a/site_tmpl/myevents.html
+++ b/site_tmpl/myevents.html
@@ -31,7 +31,7 @@
                                 <a class="btn btn-info" href="{% url 'my-cchours' instance.event.id %}">Crew Hours</a>
                                 {% endif %}
                             {% if instance.event.attachments %}
-                                <a class="btn btn-info" href="{% url 'my-eventfiles' instance.event.id %}">Files</a>
+                                <a class="btn btn-info" href="{% url "my:event-files" instance.event.id %}">Files</a>
                             {% endif %}
 
                         </div>

--- a/site_tmpl/myevents.html
+++ b/site_tmpl/myevents.html
@@ -26,9 +26,9 @@
                             <a class="btn btn-default" href="{% url 'events:pdf' instance.event.id %}">Workorder
                                 PDF </a>
                             {% if instance.event.reports_editable %}
-                                <a class="btn btn-primary" href="{% url 'my-ccreport' instance.event.id %}">CC
+                                <a class="btn btn-primary" href="{% url "my:report" instance.event.id %}">CC
                                     Report</a>
-                                <a class="btn btn-info" href="{% url 'my-cchours' instance.event.id %}">Crew Hours</a>
+                                <a class="btn btn-info" href="{% url "my:hours-list" instance.event.id %}">Crew Hours</a>
                                 {% endif %}
                             {% if instance.event.attachments %}
                                 <a class="btn btn-info" href="{% url "my:event-files" instance.event.id %}">Files</a>

--- a/site_tmpl/myhours.html
+++ b/site_tmpl/myhours.html
@@ -1,7 +1,7 @@
 {% extends 'base_admin.html' %}
 
 {% block content %}
-    <h1><a href="{% url "my-events" %}">My</a> Hours for '<em>{{event}}</em>'</h1>
+    <h1><a href="{% url "my:events" %}">My</a> Hours for '<em>{{event}}</em>'</h1>
     <table class="table">
         <thead>
         <tr>
@@ -22,5 +22,5 @@
     </table>
     <a class="btn btn-primary btn-lg" href="{% url "my-cchours-bulk" event.id %}">Bulk Add</a>
     <a class="btn btn-warning btn-lg" href="{% url "my-cchours-mk" event.id %}">Single Add</a>
-    <a class="btn btn-warning btn-lg" href="{% url "my-events" %}">Done</a>
+    <a class="btn btn-warning btn-lg" href="{% url "my:events" %}">Done</a>
 {% endblock %}

--- a/site_tmpl/myhours.html
+++ b/site_tmpl/myhours.html
@@ -16,11 +16,11 @@
             <td>{{ hour.user.get_full_name }}</td>
             <td>{{ hour.hours }}</td>
             <td>{{ hour.service }}</td>
-            <td><a href="{% url "my-cchours-edit" event.id hour.user.id %}">Update</a>
+            <td><a href="{% url "my:hours-edit" event.id hour.user.id %}">Update</a>
         </tr>
     {% endfor %}
     </table>
-    <a class="btn btn-primary btn-lg" href="{% url "my-cchours-bulk" event.id %}">Bulk Add</a>
-    <a class="btn btn-warning btn-lg" href="{% url "my-cchours-mk" event.id %}">Single Add</a>
+    <a class="btn btn-primary btn-lg" href="{% url "my:hours-bulk" event.id %}">Bulk Add</a>
+    <a class="btn btn-warning btn-lg" href="{% url "my:hours-new" event.id %}">Single Add</a>
     <a class="btn btn-warning btn-lg" href="{% url "my:events" %}">Done</a>
 {% endblock %}

--- a/site_tmpl/myorgsincharge.html
+++ b/site_tmpl/myorgsincharge.html
@@ -13,7 +13,7 @@
     {% for org in orgs %}
             <tr>
                 <td><a href="{% url 'my:org-edit' org.id %}">{{org}}</a></td>
-                <td><a href="{% url 'my-orgs-xfer' org.id %}">Transfer Ownership</a>
+                <td><a href="{% url "my:org-transfer" org.id %}">Transfer Ownership</a>
             </tr>
     {% empty %}
         <tr>

--- a/site_tmpl/mywo.html
+++ b/site_tmpl/mywo.html
@@ -25,7 +25,7 @@
                     {% if not event.closed and not event.cancelled and not event.over %}
                     <a class="btn btn-primary" href="{% url "my:event-attach" event.id %}">Attachments</a>
                     {% endif %}
-                    <a class="btn btn-default"  href="{% url 'my-events-pdf' event.id %}">Workorder PDF </a>
+                    <a class="btn btn-default"  href="{% url 'events:pdf' event.id %}">Workorder PDF </a>
                     {# <a class="btn btn-default">Repeat </a> #}
                 </td>
             </tr>

--- a/site_tmpl/org_detail.html
+++ b/site_tmpl/org_detail.html
@@ -140,7 +140,7 @@
                 {% permission user has 'events.view_event' of e %}
             <tr>
                 <td>
-                    <a href="{% url "events.views.flow.viewevent" e.id %}">{{ e }}</a>
+                    <a href="{% url "events:detail" e.id %}">{{ e }}</a>
                 </td>
                 <td>
                     {{ e.datetime_end }}

--- a/site_tmpl/projectionlist.html
+++ b/site_tmpl/projectionlist.html
@@ -3,11 +3,11 @@
 {% load permissionif %}
 {% block content %}
 <div class="pull-right">
-    <a class="btn btn-warning btn-lg" href="{% url "projection-list-detail" %}"><i class="glyphicon glyphicon-th icon-white"></i>&nbsp;Detailed List</a>
+    <a class="btn btn-warning btn-lg" href="{% url "projection:grid" %}"><i class="glyphicon glyphicon-th icon-white"></i>&nbsp;Detailed List</a>
     {% permission request.user has 'projection.edit_pits' %}
-        <a class="btn btn-info btn-lg" href="{% url "projection-bulk-update" %}"><i class="glyphicon glyphicon-fast-forward icon-white"></i>Bulk Update Projectionists</a>
+        <a class="btn btn-info btn-lg" href="{% url "projection:bulk-edit" %}"><i class="glyphicon glyphicon-fast-forward icon-white"></i>Bulk Update Projectionists</a>
     {% endpermission %}
-    <a class="btn btn-info btn-lg" href="{% url "events:pdf-multi" %}"><i class="glyphicon glyphicon-print icon-white"></i>PDF</a>
+    <a class="btn btn-info btn-lg" href="{% url "projection:pdf" %}"><i class="glyphicon glyphicon-print icon-white"></i>PDF</a>
 </div>
 <h2> {{ h2 }} </h2>
 <table class="table table-striped table-bordered">
@@ -27,7 +27,7 @@
         {% endif %}
                 <td>
                     {% permission request.user has 'projection.edit_pits' %}
-                        <a href="{% url "projection-update" user.id %}">
+                        <a href="{% url "projection:edit" user.id %}">
                             {{ user }}
                         </a>
                     {% else %}
@@ -48,6 +48,6 @@
     
 </table>
                         {% permission request.user has 'projection.edit_pits' %}
-<a class="btn btn-lg btn-primary" href="{% url "projection-create" %}">Create</a>
+<a class="btn btn-lg btn-primary" href="{% url "projection:new" %}">Create</a>
     {% endpermission %}
 {% endblock %}

--- a/site_tmpl/projectionlist.html
+++ b/site_tmpl/projectionlist.html
@@ -7,7 +7,7 @@
     {% permission request.user has 'projection.edit_pits' %}
         <a class="btn btn-info btn-lg" href="{% url "projection-bulk-update" %}"><i class="glyphicon glyphicon-fast-forward icon-white"></i>Bulk Update Projectionists</a>
     {% endpermission %}
-    <a class="btn btn-info btn-lg" href="{% url "events-pdf-multi" %}"><i class="glyphicon glyphicon-print icon-white"></i>PDF</a>
+    <a class="btn btn-info btn-lg" href="{% url "events:pdf-multi" %}"><i class="glyphicon glyphicon-print icon-white"></i>PDF</a>
 </div>
 <h2> {{ h2 }} </h2>
 <table class="table table-striped table-bordered">

--- a/site_tmpl/projectionlist_detail.html
+++ b/site_tmpl/projectionlist_detail.html
@@ -3,11 +3,11 @@
 {% load permissionif %}
 {% block content %}
 <div class="pull-right">
-    <a class="btn btn-warning btn-lg" href="{% url "projection-list" %}"><i class="glyphicon glyphicon-th-large icon-white"></i>&nbsp;Standard List</a>
+    <a class="btn btn-warning btn-lg" href="{% url "projection:list" %}"><i class="glyphicon glyphicon-th-large icon-white"></i>&nbsp;Standard List</a>
     {% permission request.user has 'projection.edit_pits' %}
-        <a class="btn btn-info btn-lg" href="{% url "projection-bulk-update" %}"><i class="glyphicon glyphicon-fast-forward icon-white"></i>Bulk Update Projectionists</a>
+        <a class="btn btn-info btn-lg" href="{% url "projection:bulk-edit" %}"><i class="glyphicon glyphicon-fast-forward icon-white"></i>Bulk Update Projectionists</a>
     {% endpermission %}
-    <a class="btn btn-info btn-lg" href="{% url "events:pdf-multi" %}"><i class="glyphicon glyphicon-print icon-white"></i>PDF</a>
+    <a class="btn btn-info btn-lg" href="{% url "projection:pdf" %}"><i class="glyphicon glyphicon-print icon-white"></i>PDF</a>
 </div>
 <h2> {{ h2 }} </h2>
 <h3> Projectionists In Training </h3>
@@ -29,7 +29,7 @@
                 
                 <td>
                     {% permission request.user has 'projection.edit_pits' %}
-                        <a href="{% url "projection-update" user.id %}">{{ user }}</a>
+                        <a href="{% url "projection:edit" user.id %}">{{ user }}</a>
                     {% else %}
                         {{ user }}
                     {% endpermission %}
@@ -51,7 +51,7 @@
 {% for user in licensed_users %}
     <li>
         {% permission request.user has 'projection.edit_pits' %}
-            <a href="{% url "projection-update" user.id %}">{{ user }}</a>
+            <a href="{% url "projection:edit" user.id %}">{{ user }}</a>
         {% else %}
             {{ user }}
         {% endpermission %}
@@ -75,7 +75,7 @@
 {% for user in alumni_users %}
     <li>
         {% permission request.user has 'projection.edit_pits' %}
-            <a href="{% url "projection-update" user.id %}">{{ user }}</a>
+            <a href="{% url "projection:edit" user.id %}">{{ user }}</a>
         {% else %}
             {{ user }}
         {% endpermission %}
@@ -94,7 +94,7 @@
 {% endfor %}
 </ul>
 {% permission request.user has 'projection.edit_pits' %}
-    <a class="btn btn-lg btn-primary" href="{% url "projection-create" %}">Create</a>
+    <a class="btn btn-lg btn-primary" href="{% url "projection:new" %}">Create</a>
 {% endpermission %}
 
 {% endblock %}

--- a/site_tmpl/projectionlist_detail.html
+++ b/site_tmpl/projectionlist_detail.html
@@ -7,7 +7,7 @@
     {% permission request.user has 'projection.edit_pits' %}
         <a class="btn btn-info btn-lg" href="{% url "projection-bulk-update" %}"><i class="glyphicon glyphicon-fast-forward icon-white"></i>Bulk Update Projectionists</a>
     {% endpermission %}
-    <a class="btn btn-info btn-lg" href="{% url "events-pdf-multi" %}"><i class="glyphicon glyphicon-print icon-white"></i>PDF</a>
+    <a class="btn btn-info btn-lg" href="{% url "events:pdf-multi" %}"><i class="glyphicon glyphicon-print icon-white"></i>PDF</a>
 </div>
 <h2> {{ h2 }} </h2>
 <h3> Projectionists In Training </h3>

--- a/site_tmpl/registration/login.html
+++ b/site_tmpl/registration/login.html
@@ -42,12 +42,12 @@
                     Automatically send me to CAS in the future.
                 </label>
             </form>
-            <a class="btn btn-lg btn-block btn-primary" href="{% url "login" %}?force_cas=true{% if request.GET.next %}&next={{ request.GET.next | urlencode }}{% endif %}"> CAS Login</a>
+            <a class="btn btn-lg btn-block btn-primary" href="{% url "accounts:login" %}?force_cas=true{% if request.GET.next %}&next={{ request.GET.next | urlencode }}{% endif %}"> CAS Login</a>
         </div>
         <div class="col-md-5 login">
             <h2> Login via Local Account </h2>
             {% crispy form %}
-            <p class="muted text-muted"><a href="{% url "django.contrib.auth.views.password_reset" %}"> Forgot your password? </a></p>
+            <p class="muted text-muted"><a href="{% url "accounts:reset:start" %}"> Forgot your password? </a></p>
         </div>
 
     </div>

--- a/site_tmpl/registration/logout.html
+++ b/site_tmpl/registration/logout.html
@@ -8,7 +8,7 @@
 <div class="container marketing" style="text-align:center;">
     <div class="col-md-12">
         <h2>Logged out</h2>
-        <p class="lead">Thanks for spending some quality time with the Web site today. <br /><a href="{% url "django.contrib.auth.views.login" %}">Log in Again</a></p>
+        <p class="lead">Thanks for spending some quality time with the Web site today. <br /><a href="{% url "accounts:login" %}">Log in Again</a></p>
     </div>
 </div>
 

--- a/site_tmpl/registration/password_reset_email.html
+++ b/site_tmpl/registration/password_reset_email.html
@@ -5,12 +5,12 @@ LNL Password Reset
     to the following page and choose a new password:
 
 {% block reset_link %}
-http://lnl.wpi.edu{% url 'django.contrib.auth.views.password_reset_confirm' uidb64=uid token=token %}
+http://lnl.wpi.edu{% url "accounts:reset:confirm" uidb64=uid token=token %}
 {% endblock %}
 
 Your username, in case you've forgotten: {{ user.username }}. If this isn't you, you can safely ignore this email.
 
-    You can log in at http://lnl.wpi.edu{% url 'django.contrib.auth.views.login' %}. If you use WPI CAS, you can
+    You can log in at http://lnl.wpi.edu{% url "accounts:login" %}. If you use WPI CAS, you can
     continue to use that, in addition to having your manual password set.
 
     Thanks for using the LNL Database

--- a/site_tmpl/registration/reset_password_finished.html
+++ b/site_tmpl/registration/reset_password_finished.html
@@ -8,7 +8,7 @@
 <div class="container marketing" style="text-align:center;">
     <div class="col-md-12">
         <h2> Password reset complete </h2>
-        <p class="lead">Your password has been set. You may go ahead and <a href="{% url "django.contrib.auth.views.login" %}">log in now.</a></p>
+        <p class="lead">Your password has been set. You may go ahead and <a href="{% url "accounts:login" %}">log in now.</a></p>
     </div>
 </div>
 

--- a/site_tmpl/static_page.html
+++ b/site_tmpl/static_page.html
@@ -22,7 +22,7 @@
             <div class="carousel-caption">
               <h1>{{ img.href }}</h1>
               <p>{{ img.href_desc }}</p>
-              <p><a class="btn btn-lg btn-primary" href="{% url "pages.views.page" img.href.slug %}">{{ img.href_words }}</a></p>
+              <p><a class="btn btn-lg btn-primary" href="{% url "page" img.href.slug %}">{{ img.href_words }}</a></p>
             </div>
             {% else %}
             <div class="carousel-caption">

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -571,9 +571,9 @@
                     </table>
                     <h2> Bills </h2>
 							{% if event.reviewed %}
-                    <a class="btn btn-primary" href="{% url "events:pdf-bill" event.id %}">Download Invoice</a>
+                    <a class="btn btn-primary" href="{% url "events:bills:pdf" event.id %}">Download Invoice</a>
 							{% else %}
-                    <a class="btn btn-primary" href="{% url "events:pdf-bill" event.id %}">Download Quote</a>
+                    <a class="btn btn-primary" href="{% url "events:bills:pdf" event.id %}">Download Quote</a>
 							{% endif %}
                     {% if event.billings %}
                         <table class="table">

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -100,7 +100,7 @@
                     </div>
                     <div class="modal-footer">
                         <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Go Back</button>
-                        <a class="btn btn-primary" href="{% url "event-cancel" event.id %}">Cancel Event</a>
+                        <a class="btn btn-primary" href="{% url "events:cancel" event.id %}">Cancel Event</a>
                     </div>
                 </div>
             </div>

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -32,7 +32,7 @@
                         {% permission request.user has 'events.approve_event' of event %}
                             <a class="btn btn-success btn-lg" href="{% url "events:approve" event.id %}">Approve</a>
                             <a class="btn btn-danger btn-lg"
-                               href="{% url "events.views.flow.denial" event.id %}">Deny</a>
+                               href="{% url "events:deny" event.id %}">Deny</a>
                         {% endpermission %}
                     {% else %}
                         {% if not event.reviewed %}

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -20,7 +20,7 @@
                 {% else %}
                     {% permission request.user has 'events.edit_event_text' of event or request.user has 'events.edit_event_times' of event %}
                         <a class="btn btn-warning btn-lg"
-                           href="{% url "events.views.mkedrm.eventnew" event.id %}">Edit</a>
+                           href="{% url "events:edit" event.id %}">Edit</a>
                     {% endpermission %}
                     {% if not event.reviewed %}
                         {% permission request.user has 'events.cancel_event' of event %}

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -42,7 +42,7 @@
                             {% endpermission %}
                         {% else %}
                             {% permission request.user has 'events.bill_event' of event %}
-                                <a class="btn btn-primary btn-lg" href="{% url "event-mkbilling" event.id %}">Create
+                                <a class="btn btn-primary btn-lg" href="{% url "events:bills:new" event.id %}">Create
                                     Bill</a>
                             {% endpermission %}
                             {% permission request.user has 'events.close_event' of event %}
@@ -596,9 +596,9 @@
                                         <td>
                                             {% if not event.closed %}
                                                 <a class="btn btn-link"
-                                                   href="{% url "event-updbilling" event.id billing.id %}">Update</a>
+                                                   href="{% url "events:bills:edit" event.id billing.id %}">Update</a>
                                                 {% if not billing.date_paid %}<a class="btn btn-link"
-                                                                                 href="{% url "event-rmbilling" event.id billing.id %}">Delete</a>
+                                                                                 href="{% url "events:bills:remove" event.id billing.id %}">Delete</a>
                                                 {% endif %}
                                             {% endif %}
                                         </td>

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -123,7 +123,7 @@
                         </div>
                         <div class="modal-footer">
                             <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Go Back</button>
-                            <a class="btn btn-primary" href="{% url "event-reopen" event.id %}">Reopen Event</a>
+                            <a class="btn btn-primary" href="{% url "events:reopen" event.id %}">Reopen Event</a>
                         </div>
                     </div>
                 </div>

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -353,7 +353,7 @@
                     
                 </div>
                 <div id="crew" class="tab-pane">
-                    <a class="btn btn-lg btn-info pull-right" href="{% url "events.views.flow.assigncc" event.id %}">Modify</a>
+                    <a class="btn btn-lg btn-info pull-right" href="{% url "events:chiefs" event.id %}">Modify</a>
                     <h2> Crew Chief(s) </h2>
                     <table class="table">
                         <tr>

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -30,7 +30,7 @@
                     {% endif %}
                     {% if not event.approved %}
                         {% permission request.user has 'events.approve_event' of event %}
-                            <a class="btn btn-success btn-lg" href="{% url "events.views.flow.approval" event.id %}">Approve</a>
+                            <a class="btn btn-success btn-lg" href="{% url "events:approve" event.id %}">Approve</a>
                             <a class="btn btn-danger btn-lg"
                                href="{% url "events.views.flow.denial" event.id %}">Deny</a>
                         {% endpermission %}

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -392,7 +392,7 @@
                 <div id="reports" class="tab-pane">
                     {% if not event.closed or not event.cancelled %}
                         <div class="pull-right">
-                            <a class="btn btn-primary btn-lg" href="{% url "event-mkccr" event.id%}">New</a>
+                            <a class="btn btn-primary btn-lg" href="{% url "events:reports:new" event.id%}">New</a>
                         </div>
                     {% endif %}
                     <h2>Reports</h2>
@@ -405,10 +405,10 @@
                             {% endif %}
                             {% if not event.closed or not event.cancelled %}
                                 {% permission request.user has 'events.change_ccreport' of report %}
-                                    [<a href="{% url "event-updccr" event.id report.id %}">Edit</a>]
+                                    [<a href="{% url "events:reports:edit" event.id report.id %}">Edit</a>]
                                 {% endpermission %}
                                 {% permission request.user has 'events.delete_ccreport' of report %}
-                                    [<a href="{% url "event-rmccr" event.id report.id %}">Delete</a>]
+                                    [<a href="{% url "events:reports:remove" event.id report.id %}">Delete</a>]
                                 {% endpermission %}
                             {% endif %}
                         </em>
@@ -571,9 +571,9 @@
                     </table>
                     <h2> Bills </h2>
 							{% if event.reviewed %}
-                    <a class="btn btn-primary" href="{% url 'events-pdf-bill' event.id %}">Download Invoice</a>
+                    <a class="btn btn-primary" href="{% url "events:pdf-bill" event.id %}">Download Invoice</a>
 							{% else %}
-                    <a class="btn btn-primary" href="{% url 'events-pdf-bill' event.id %}">Download Quote</a>
+                    <a class="btn btn-primary" href="{% url "events:pdf-bill" event.id %}">Download Quote</a>
 							{% endif %}
                     {% if event.billings %}
                         <table class="table">

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -76,7 +76,7 @@
                     </div>
                     <div class="modal-footer">
                         <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">Go Back</button>
-                        <a class="btn btn-primary" href="{% url "event-close" event.id %}">Close Event</a>
+                        <a class="btn btn-primary" href="{% url "events:close" event.id %}">Close Event</a>
                     </div>
                 </div>
             </div>

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -618,7 +618,7 @@
                 </div>
                 {% endpermission %}
                 <div id="files" class="tab-pane">
-                    <div class="pull-right">{% if not event.closed %}<a class="btn btn-warning" href="{% url "eventattachments" event.id %}">Edit</a>{% endif %}</div>
+                    <div class="pull-right">{% if not event.closed %}<a class="btn btn-warning" href="{% url "events:files" event.id %}">Edit</a>{% endif %}</div>
                     <h2> Files </h2> 
                     <table class="table">
                         <tr>

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -37,7 +37,7 @@
                     {% else %}
                         {% if not event.reviewed %}
                             {% permission request.user has 'events.review_event' of event %}
-                                <a class="btn btn-success btn-lg" href="{% url "events.views.flow.review" event.id %}">Review
+                                <a class="btn btn-success btn-lg" href="{% url "events:review" event.id %}">Review
                                     For Billing</a>
                             {% endpermission %}
                         {% else %}

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -291,7 +291,7 @@
                     </table>
                 </div>
                 <div id="services" class="tab-pane">
-                    <div class="pull-right"><a class="btn btn-lg btn-info" href="{% url "eventextras" event.id %}">Modify Extras</a></div>
+                    <div class="pull-right"><a class="btn btn-lg btn-info" href="{% url "events:extras" event.id %}">Modify Extras</a></div>
                     {% if event.lighting %}
                         <h2>Lighting Services ({{ event.lighting }})</h2>
                         <h3>Requirements:</h3>
@@ -455,8 +455,8 @@
                 <div id="billing" class="tab-pane">
                     {% permission request.user has 'events.adjust_event_charges' of event %}
                         <div class="pull-right btn-group">
-                            <a class="btn btn-lg btn-primary" href="{% url "eventextras" event.id %}">Modify Extras</a>
-                            <a class="btn btn-lg btn-info" href="{% url "eventoneoff" event.id %}">Add OneOff
+                            <a class="btn btn-lg btn-primary" href="{% url "events:extras" event.id %}">Modify Extras</a>
+                            <a class="btn btn-lg btn-info" href="{% url "events:oneoffs" event.id %}">Add OneOff
                                 Charges</a>
                         </div>
                     {% endpermission %}

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -379,7 +379,7 @@
                         {% endfor %}
                     </table>
                     {% comment %}
-                    <a class="btn btn-lg btn-info pull-right" href="{% url "events.views.flow.assigncrew" event.id %}">Modify</a>
+                    <a class="btn btn-lg btn-info pull-right" href="{% url "events:add-crew" event.id %}">Modify</a>
                     <h2> Crew </h2>
                     <ul>
                         {% for c in event.crew.all %}
@@ -431,7 +431,7 @@
                         {% endfor %}
                         </ul>
                     {% endif %}
-                    <div class="pull-right"><a class="btn btn-primary btn-lg" href="{% url "admin-cchours-bulk" event.id %}">Edit</a></div>
+                    <div class="pull-right"><a class="btn btn-primary btn-lg" href="{% url "events:add-bulk-crew" event.id %}">Edit</a></div>
                     <h2> Hours </h2>
                     <table class="table">
                         <thead>

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -11,7 +11,7 @@
             <h3>Status: <b>{{ event.status }}</b></h3>
 
             <div class="btn-group">
-                <a class="btn btn-info btn-lg" href="{% url "events-pdf" event.id %}">PDF</a>
+                <a class="btn btn-info btn-lg" href="{% url "events:pdf" event.id %}">PDF</a>
                 {% if event.closed or event.cancelled %}
                     {% permission request.user has 'events.reopen_event' of event %}
                         <a class="btn btn-default btn-lg" href="#reopenModal" role="button"

--- a/site_tmpl/userdetail.html
+++ b/site_tmpl/userdetail.html
@@ -70,10 +70,10 @@
             <h3>Events CC'd</h3>
             <ul class="list-unstyled">
                 {% for event in ccs %}
-                    <li><a href="{% url "events-detail" event.event.id %}">{{ event.event }}</a> ({{ event.event.datetime_start }})</li>
+                    <li><a href="{% url "events:detail" event.event.id %}">{{ event.event }}</a> ({{ event.event.datetime_start }})</li>
                 {% endfor %}
                 {% for event in u.crewchiefx.all %}
-                    <li><a href="{% url "events-detail" event.id %}">{{ event }}</a> ({{ event.datetime_start }})</li>
+                    <li><a href="{% url "events:detail" event.id %}">{{ event }}</a> ({{ event.datetime_start }})</li>
                 {% endfor %}
             </ul>
         </div>
@@ -83,7 +83,7 @@
             <h3>Events Participated</h3>
             <ul class="list-unstyled">
                 {% for h in hours %}
-                    <li><a href="{% url "events-detail" h.event.id %}">{{ h.event }} {% if h.service %} ({{h.service.shortname  }}) {% else %} (N/A) {% endif %}:</a> {{ h.hours }}h</li>
+                    <li><a href="{% url "events:detail" h.event.id %}">{{ h.event }} {% if h.service %} ({{h.service.shortname  }}) {% else %} (N/A) {% endif %}:</a> {{ h.hours }}h</li>
                 {% endfor %}
             </ul>
         </div>

--- a/site_tmpl/watson/includes/search_result_events_ccreport.html
+++ b/site_tmpl/watson/includes/search_result_events_ccreport.html
@@ -3,7 +3,7 @@
 {% block search_result %}
     <h2><span class="glyphicon glyphicon-{{ result.object.glyphicon|default_if_none:'asterisk' }}"
               aria-hidden="true"></span> <a
-            href="{% url 'events-detail' result.object.event.id %}">Report for {{ result.object.event.event_name }}</a>
+            href="{% url 'events:detail' result.object.event.id %}">Report for {{ result.object.event.event_name }}</a>
     <span class="result-subtitle">Crew Chief Report -
         <a href='{% url 'accounts:detail' result.object.crew_chief.id %}'>
             {{ result.object.crew_chief }}

--- a/site_tmpl/watson/includes/search_result_events_event.html
+++ b/site_tmpl/watson/includes/search_result_events_event.html
@@ -3,7 +3,7 @@
 {% block search_result %}
     <h2><span class="glyphicon glyphicon-{{ result.object.glyphicon|default_if_none:'asterisk' }}"
               aria-hidden="true"></span> <a
-            href="{% url 'events-detail' result.object.id %}">{{ result.title }}
+            href="{% url 'events:detail' result.object.id %}">{{ result.title }}
         ({{ result.object.short_services }})</a>
         <span class="result-subtitle">Event - {{ result.object.status }}</span></h2>
     <h3>{{ result.object.datetime_nice }} - {{ result.object.location.name }}</h3>


### PR DESCRIPTION
This one's been on the backburner since February. 

Essentially, you always want to refer to a URL not by its actual URL (because it may change or need to have some info filled into it). Previously, you could refer to it either by an arbitrary tag or the full path to the function the URL points to. But names were stupid and increasingly arcane, functions should never be referred to in strings, we can't update to the latest stuff because they dropped function path support, and everything was in one massive and hideous urls file. So this pretty much replaces all of the urls in the app, period, and splits up the giant urls.py to some smaller ones you can actually read.