### PR TITLE
Fix email links

### DIFF
--- a/data/templatetags/lnldb_tags.py
+++ b/data/templatetags/lnldb_tags.py
@@ -1,5 +1,6 @@
 from django import template
 from django.utils.timezone import localtime
+from django.conf import settings
 
 register = template.Library()
 
@@ -20,3 +21,15 @@ def daterange(datetime_start, datetime_end):
 @register.filter()
 def is_list(string):
     return hasattr(string, '__iter__') and not isinstance(string, basestring)
+
+@register.simple_tag(takes_context=True)
+def get_base_url(context):
+    if 'request' in context:
+        request = context['request']
+        return "%s://%s" % (request.scheme, request.get_host())
+    # try to guess if the server has https
+    is_secure = settings.SECURE_SSL_REDIRECT or settings.SESSION_COOKIE_SECURE\
+            or settings.SECURE_HSTS_SECONDS
+    scheme = 'https' if is_secure else 'http'
+    return '%s://%s' % (scheme, settings.ALLOWED_HOSTS[0])
+

--- a/site_tmpl/emails/email_base.html
+++ b/site_tmpl/emails/email_base.html
@@ -1,3 +1,4 @@
+{% load lnldb_tags %}
 <html>
     <head>
         <title></title>
@@ -192,7 +193,7 @@
                     <table class="w325" width="350" cellpadding="0" cellspacing="0" border="0">
                         <tbody><tr><td class="w325" width="350" height="8"></td></tr>
                     </tbody></table>
-                    <div class="header-content">{% block perma %}<a href="#GABE ADD STUFF HERE" class="cm-webversion">View Online</a>{% endblock %}</div>
+                    <div class="header-content">{% block perma %}{% endblock %}</div>
                     <table class="w325" width="350" cellpadding="0" cellspacing="0" border="0">
                         <tbody><tr><td class="w325" width="350" height="8"></td></tr>
                     </tbody></table>
@@ -233,7 +234,7 @@
                     <td class="w580" width="580">
                         <div align="center" id="headline">
                             <p>
-                            <strong><a href="{{ request.scheme }}://{{ request.get_host }}/"><span class="cm-singleline" label="Title">WPI Lens and Lights</span></a></strong>
+                            <strong><a href="{% get_base_url %}/"><span class="cm-singleline" label="Title">WPI Lens and Lights</span></a></strong>
                             </p>
                         </div>
                     </td>

--- a/site_tmpl/emails/email_notice.html
+++ b/site_tmpl/emails/email_notice.html
@@ -1,8 +1,10 @@
 {% extends "emails/email_base.html" %}
 {% load tz %}
 {% load markdown_deux_tags %}
+{% load lnldb_tags %}
+
 {% block perma %}
-<a href="{{ request.scheme }}://{{ request.get_host}}{% url "emails:pre-meeting" object.uuid %}/" class="cm-webversion">View Online</a>
+<a href="{% get_base_url %}{% url "emails:pre-meeting" object.uuid %}/" class="cm-webversion">View Online</a>
 {% endblock %}
 
 {% block unsub %}

--- a/site_tmpl/emails/email_notice_cc.html
+++ b/site_tmpl/emails/email_notice_cc.html
@@ -1,9 +1,10 @@
 {% extends "emails/email_base.html" %}
 {% load tz %}
 {% load markdown_deux_tags %}
+{% load lnldb_tags %}
 
 {% block perma %}
-<a href="{{ request.scheme }}://{{ request.get_host}}{% url "emails:post-meeting" object.uuid %}/" class="cm-webversion">View Online</a>
+<a href="{% get_base_url %}{% url "emails:post-meeting" object.uuid %}/" class="cm-webversion">View Online</a>
 {% endblock %}
 
 {% block unsub %}


### PR DESCRIPTION
Email templates didn't get enough info for the hostname to appear. Added
the {% get_base_url %} function to rectify this. Fix for #410 