### PR TITLE
Make all events button show all events

### DIFF
--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -25,7 +25,7 @@ urlpatterns = [
     url(r'^paid/', generate_date_patterns(list_views.paid, name="paid")),
     url(r'^unpaid/', generate_date_patterns(list_views.unpaid, name="unpaid")),
     url(r'^closed/', generate_date_patterns(list_views.closed, name="closed")),
-    url(r'^approved/', generate_date_patterns(list_views.approved, name="approved")),
+    url(r'^all/', generate_date_patterns(list_views.all, name="all")),
 
     # Actual event pages
 

--- a/events/views/list.py
+++ b/events/views/list.py
@@ -663,6 +663,8 @@ def all(request, start=None, end=None):
                        FakeExtendedField('datetime_start', verbose_name="Starting At"),
                        FakeField('short_services', verbose_name="Services", sortable=False),
                        FakeField('tasks')]
+    if request.user.has_perm('events.approve_event'):
+        context['cols'].append('approved')
     context['cols'] = map_fields(context['cols'])  # must use because there are strings
     return render(request, 'events.html', context)
 

--- a/events/views/list.py
+++ b/events/views/list.py
@@ -626,7 +626,7 @@ def closed(request, start=None, end=None):
 
 @login_required
 @permission_required('events.view_event', raise_exception=True)
-def approved(request, start=None, end=None):
+def all(request, start=None, end=None):
     if not start and not end:
         today = datetime.date.today()
         start = today - datetime.timedelta(days=3652.5)
@@ -635,11 +635,13 @@ def approved(request, start=None, end=None):
         end = end.strftime('%Y-%m-%d')
     context = {}
 
-    events = Event.objects.filter(approved=True).distinct()
+    events = Event.objects.distinct()
     if not request.user.has_perm('events.event_view_sensitive'):
         events = events.exclude(sensitive=True)
     if not request.user.has_perm('events.event_view_debug'):
         events = events.exclude(test_event=True)
+    if not request.user.has_perm('events.approve_event'):
+        events = events.exclude(approved=False)
     events = events.select_related('location__building').prefetch_related('org') \
         .prefetch_related('otherservices').prefetch_related('ccinstances__crew_chief') \
         .prefetch_related('billings') \
@@ -650,9 +652,9 @@ def approved(request, start=None, end=None):
     sort = request.GET.get('sort')
     events = paginate_helper(events, page, sort)
 
-    context['h2'] = "Approved Events"
+    context['h2'] = "All Events"
     context['events'] = events
-    context['baseurl'] = reverse("events:approved")
+    context['baseurl'] = reverse("events:all")
     context['pdfurl'] = reverse('events:pdf-multi')
     context['cols'] = ['event_name',
                        'org',

--- a/site_tmpl/admin.nav.html
+++ b/site_tmpl/admin.nav.html
@@ -52,7 +52,7 @@
                         <li><a href="{% url "events:upcoming" %}">Upcoming Events</a></li>
                         <li><a href="{% url "events:open" %}">Open Events</a></li>
                         <li><a href="{% url "events:closed" %}">Closed Events</a></li>
-                        <li><a href="{% url "events:approved" %}">All Events</a></li>
+                        <li><a href="{% url "events:all" %}">All Events</a></li>
                         {% endpermission %}
 
 


### PR DESCRIPTION
Modify the all events page to really show all events (no longer exclude unapproved events).  Add an 'approved' column to the all events page.  Unapproved events and the approved column are only shown if the user has approve_event permission.