### PR TITLE
Email improvements

### DIFF
--- a/emails/generators.py
+++ b/emails/generators.py
@@ -160,8 +160,7 @@ class DefaultLNLEmailGenerator(object):  # yay classes
 
         template_txt = "%s.txt" % template_basename
         content_txt = render_to_string(template_txt, context)
-        # print bcc
-        self.email = EmailMultiAlternatives(subject, content_txt, from_email, to_emails, bcc=bcc, cc=bcc)
+        self.email = EmailMultiAlternatives(subject, content_txt, from_email, to_emails, bcc=bcc, cc=cc)
         for a in attachments:
             self.email.attach(a['name'], a['file_handle'], "application/pdf")
 

--- a/emails/generators.py
+++ b/emails/generators.py
@@ -172,3 +172,92 @@ class DefaultLNLEmailGenerator(object):  # yay classes
 
     def send(self):
         self.email.send()
+
+
+class EventEmailGenerator(DefaultLNLEmailGenerator):
+    def __init__(self,
+            event=None,
+            subject="LNL Event",
+            to_emails=settings.DEFAULT_TO_ADDR,
+            from_email=settings.DEFAULT_FROM_ADDR,
+            context=None,
+            template_basename="emails/email_event",
+            build_html=True,
+            body=None,
+            bcc=None,
+            cc=None,
+            attachments=None):
+        if context is None:
+            context = {}
+        context['event'] = event
+        super(EventEmailGenerator, self).__init__(
+                subject=subject,
+                to_emails=to_emails,
+                from_email=from_email,
+                context=context,
+                template_basename=template_basename,
+                build_html=build_html,
+                body=body,
+                bcc=bcc,
+                cc=cc,
+                attachments=attachments)
+
+
+class CcAddEmailGenerator(DefaultLNLEmailGenerator):
+    def __init__(self,
+            ccinstance=None,
+            subject="Crew Chief Add Notification",
+            to_emails=None,
+            from_email=settings.DEFAULT_FROM_ADDR,
+            context=None,
+            template_basename="emails/email_ccadd",
+            build_html=True,
+            bcc=None,
+            cc=None,
+            attachments=None):
+        if to_emails is None:
+            to_emails = [ccinstance.crew_chief.email]
+        if context is None:
+            context = {}
+        context['ccinstance'] = ccinstance
+        super(CcAddEmailGenerator, self).__init__(
+                subject=subject,
+                to_emails=to_emails,
+                from_email=from_email,
+                context=context,
+                template_basename=template_basename,
+                build_html=build_html,
+                body=None,
+                bcc=bcc,
+                cc=cc,
+                attachments=attachments)
+
+
+class ReportReminderEmailGenerator(DefaultLNLEmailGenerator):
+    def __init__(self,
+            reminder=None,
+            subject="LNL Crew Chief Report Reminder Email",
+            to_emails=None,
+            from_email=settings.DEFAULT_FROM_ADDR,
+            context=None,
+            template_basename="emails/email_reportreminder",
+            build_html=True,
+            bcc=None,
+            cc=None,
+            attachments=None):
+        if to_emails is None:
+            to_emails = [reminder.crew_chief.email]
+        if context is None:
+            context = {}
+        context['reminder'] = reminder
+        super(ReportReminderEmailGenerator, self).__init__(
+                subject=subject,
+                to_emails=to_emails,
+                from_email=from_email,
+                context=context,
+                template_basename=template_basename,
+                build_html=build_html,
+                body=None,
+                bcc=bcc,
+                cc=cc,
+                attachments=attachments)

--- a/events/signals.py
+++ b/events/signals.py
@@ -6,7 +6,7 @@ from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.text import slugify
 
-from emails.generators import DefaultLNLEmailGenerator as DLEG
+from emails.generators import CcAddEmailGenerator, DefaultLNLEmailGenerator as DLEG
 from events.models import Billing, EventCCInstance, Fund
 from pdfs.views import generate_pdfs_standalone
 
@@ -19,7 +19,7 @@ __all__ = [
 
 @receiver(post_save, sender=EventCCInstance)
 def email_cc_notification(sender, instance, created, raw=False, **kwargs):
-    """ Sends an email to a crew cheif to notify them of being made one """
+    """ Sends an email to a crew chief to notify them of being made one """
     if created and not raw:
         i = instance
 
@@ -35,15 +35,7 @@ def email_cc_notification(sender, instance, created, raw=False, **kwargs):
         else:
             local_formatted = "a time of your choice "
 
-        email_body = """
-            You\'ve been added as a crew chief to the event "%s". \n
-            You have signed up to be crew chief for %s, with your setup starting on %s in the %s \n
-            \n
-            Please note that the attached Workorder PDF contains all services relating to the event,
-             not just your assigned service.
-            """ % (i.event.event_name, i.service, local_formatted, i.setup_location, )
-        e = DLEG(subject="Crew Chief Add Notification", to_emails=[instance.crew_chief.email], body=email_body,
-                 attachments=attachments)
+        e = CcAddEmailGenerator(ccinstance=i, attachments=attachments)
         e.send()
 
 

--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -41,6 +41,7 @@ urlpatterns = [
     url(r'^review/(?P<id>[0-9a-f]+)/$', flow_views.review, name="review"),
     url(r'^review/(?P<id>[0-9a-f]+)/remind/(?P<uid>[0-9a-f]+)/$',
         flow_views.reviewremind, name="remind"),
+    url(r'^review/(?P<id>[0-9a-f]+)/remind/$', flow_views.remindall, name="remindall"),
     url(r'^close/(?P<id>[0-9a-f]+)/$', flow_views.close, name="close"),
     url(r'^cancel/(?P<id>[0-9a-f]+)/$', flow_views.cancel, name="cancel"),
     url(r'^reopen/(?P<id>[0-9a-f]+)/$', flow_views.reopen, name="reopen"),

--- a/events/views/mkedrm.py
+++ b/events/views/mkedrm.py
@@ -1,30 +1,31 @@
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 
+from emails.generators import EventEmailGenerator
 from events.forms import InternalEventForm
 from events.models import Event
 
 
 @login_required
-# TODO: rework form for perm logic.
 def eventnew(request, id=None):
     context = {}
-    edit_perms = ('events.view_event',)
-    # mk_perms = ('events.add_raw_event',)
     # get instance if id is passed in
     if id:
         instance = get_object_or_404(Event, pk=id)
         context['new'] = False
-        if not (request.user.has_perms(edit_perms) or
-                request.user.has_perms(edit_perms, instance)):
+        perms = ['events.view_event']
+        if not (request.user.has_perms(perms) or
+                request.user.has_perms(perms, instance)):
             raise PermissionDenied
     else:
         instance = None
         context['new'] = True
-        if not request.user.has_perms(edit_perms):
+        perms = ['events.add_raw_event']
+        if not request.user.has_perms(perms):
             raise PermissionDenied
 
     if request.method == 'POST':
@@ -36,7 +37,40 @@ def eventnew(request, id=None):
 
         if form.is_valid():
             if instance:
+                # calculate whether an email should be sent based on the event information *before* saving the form.
+                should_send_email = not instance.test_event
+                if should_send_email:
+                    bcc=[settings.EMAIL_TARGET_VP]
+                    if instance.projection:
+                        bcc.append(settings.EMAIL_TARGET_HP)
+                    for ccinstance in instance.ccinstances.all():
+                        if ccinstance.crew_chief.email:
+                            bcc.append(ccinstance.crew_chief.email)
+                    if instance.reviewed:
+                        subject = "Reviewed Event Edited"
+                        email_body = "The following event was edited by %s after the event was reviewed for billing." % request.user.get_full_name()
+                        bcc.append(settings.EMAIL_TARGET_T)
+                    elif instance.approved:
+                        subject = "Approved Event Edited"
+                        email_body = "The following event was edited by %s after the event was approved." % request.user.get_full_name()
+                    else:
+                        subject = "Event Edited"
+                        email_body = "The following event was edited by %s." % request.user.get_full_name()
+                    if len(form.changed_data) > 0:
+                        email_body += "\nFields changed: "
+                        for field_name in form.changed_data:
+                            email_body += field_name + ", "
+                        email_body = email_body[:-2]
                 res = form.save()
+                if should_send_email:
+                    # add HP to the email if projection was just added to the event
+                    if res.projection and not settings.EMAIL_TARGET_HP in bcc:
+                        bcc.append(settings.EMAIL_TARGET_HP)
+                    to_emails=[]
+                    if request.user.email:
+                        to_emails.append(request.user.email)
+                    email = EventEmailGenerator(event=res, subject=subject, to_emails=to_emails, body=email_body, bcc=bcc)
+                    email.send()
             else:
                 res = form.save(commit=False)
                 res.submitted_by = request.user

--- a/site_tmpl/emails/email_ccadd.html
+++ b/site_tmpl/emails/email_ccadd.html
@@ -1,0 +1,46 @@
+{% extends "emails/email_base.html" %}
+{% load tz %}
+{% load lnldb_tags %}
+{% block perma %}
+{% endblock %}
+
+{% block unsub %}
+{% endblock %}
+
+{% block content %}
+<table class="w960" width="960" cellpadding="10" cellspacing="0" border="0">
+    <tbody>
+        <tr>
+            <td class="w960" width="960">
+                <p align="left" class="article-title">{{ subject }}</p>
+                <div align="left" class="article-content">
+                <p>You've been added as a crew chief to the event {{ ccinstance.event }}.<br>
+                You have signed up to be crew chief for {{ ccinstance.service }},
+                with your setup starting on {{ ccinstance.setup_start }} in the {{ ccinstance.setup_location }}.</p>
+
+                <p>Please note that the attached Workorder PDF contains all services relating to the event, not just your assigned service.</p>
+
+                <p><b>{{ ccinstance.event }}</b><br>
+                <i>{{ ccinstance.event.location }}</i><br>
+                Start: {{ ccinstance.event.datetime_start }}<br>
+                End: {{ ccinstance.event.datetime_end }}<br>
+                Setup start: {{ ccinstance.setup_start }}<br>
+                Setup complete: {{ ccinstance.event.datetime_setup_complete }}</p>
+
+                <p>See full details of this event <a href="{% get_base_url %}{% url 'events:detail' ccinstance.event.id %}">here</a>.</p>
+
+                <p>Submit your crew chief report <a href="{% get_base_url %}{% url 'my:report' ccinstance.event.id %}">here</a>.</p>
+
+                <p>Submit crew hours <a href="{% get_base_url %}{% url 'my:hours-list' ccinstance.event.id %}">here</a>.</p>
+
+                <p>If you have any questions or concerns about the above information, contact the Vice President at
+                <a href="mailto:lnl-vp@wpi.edu">lnl-vp@wpi.edu</a>.</p>
+                </div>
+            </td>
+        </tr>
+        <tr>
+            <td class="w960" width="960" height="10"></td>
+        </tr>
+        </tbody>
+</table>
+{% endblock %}

--- a/site_tmpl/emails/email_ccadd.txt
+++ b/site_tmpl/emails/email_ccadd.txt
@@ -1,0 +1,23 @@
+{% load tz %}
+{% load lnldb_tags %}
+{{ subject }}
+
+You've been added as a crew chief to the event {{ ccinstance.event }}.
+You have signed up to be crew chief for {{ ccinstance.service }}, with your setup starting on {{ ccinstance.setup_start }} in the {{ ccinstance.setup_location }}.
+
+Please note that the attached Workorder PDF contains all services relating to the event, not just your assigned service.
+
+{{ ccinstance.event }}
+Location: {{ ccinstance.event.location }}
+Start: {{ ccinstance.event.datetime_start }}
+End: {{ ccinstance.event.datetime_end }}
+Setup start: {{ ccinstance.setup_start }}
+Setup complete: {{ ccinstance.event.datetime_setup_complete }}
+
+See full details of this event at {% get_base_url %}{% url 'events:detail' ccinstance.event.id %}.
+
+Submit your crew chief report at {% get_base_url %}{% url 'my:report' ccinstance.event.id %}.
+
+Submit crew hours at {% get_base_url %}{% url 'my:hours-list' ccinstance.event.id %}.
+
+If you have any questions or concerns about the above information, contact the Vice President at lnl-vp@wpi.edu.

--- a/site_tmpl/emails/email_event.html
+++ b/site_tmpl/emails/email_event.html
@@ -1,0 +1,33 @@
+{% extends "emails/email_base.html" %}
+{% load tz %}
+{% load lnldb_tags %}
+{% block perma %}
+{% endblock %}
+
+{% block unsub %}
+{% endblock %}
+
+{% block content %}
+<table class="w960" width="960" cellpadding="10" cellspacing="0" border="0">
+    <tbody>
+        <tr>
+            <td class="w960" width="960">
+                <p align="left" class="article-title">{{ subject }}</p>
+                <div align="left" class="article-content">
+                    <p> {{ body|safe|linebreaksbr|urlize }} </p>
+                    <p><b>{{ event.event_name }}</b><br>
+                    <i>{{ event.location }}</i><br>
+                    Start: {{ event.datetime_start }}<br>
+                    End: {{ event.datetime_end }}<br>
+                    Services: {{ event.short_services }}<br>
+                    Organization to be billed: {{ event.org_to_be_billed }}</p>
+                    <p>See full details of this event <a href="{% get_base_url %}{% url 'events:detail' event.id %}">here</a>.</p>
+                </div>
+            </td>
+        </tr>
+        <tr>
+            <td class="w960" width="960" height="10"></td>
+        </tr>
+        </tbody>
+</table>
+{% endblock %}

--- a/site_tmpl/emails/email_event.txt
+++ b/site_tmpl/emails/email_event.txt
@@ -1,0 +1,14 @@
+{% load tz %}
+{% load lnldb_tags %}
+{{ subject }}
+
+{{ body|safe }}
+
+{{ event.event_name }}
+Location: {{ event.location }}
+Start: {{ event.datetime_start }}
+End: {{ event.datetime_end }}
+Services: {{ event.short_services }}
+Organization to be billed: {{ event.org_to_be_billed }}
+
+See full details of this event at {% get_base_url %}{% url 'events:detail' event.id %}.

--- a/site_tmpl/emails/email_reportreminder.html
+++ b/site_tmpl/emails/email_reportreminder.html
@@ -1,0 +1,51 @@
+{% extends "emails/email_base.html" %}
+{% load tz %}
+{% load lnldb_tags %}
+{% block perma %}
+{% endblock %}
+
+{% block unsub %}
+{% endblock %}
+
+{% block content %}
+<table class="w960" width="960" cellpadding="10" cellspacing="0" border="0">
+    <tbody>
+        <tr>
+            <td class="w960" width="960">
+                <p align="left" class="article-title">{{ subject }}</p>
+                <div align="left" class="article-content">
+                <p> This is a reminder that you have a pending crew chief report for {{ reminder.event }}. </p>
+
+                <p>Submitting a crew chief report and recording crew hours are required parts of being a crew chief.
+                These tasks are expected to be completed shortly after an event while you still have all details of the event fresh in your mind.
+                Delaying submitting your crew chief report directly delays the billing of this event.</p>
+
+                <p>Crew chief reports exist for two purposes:
+                1) to serve as a guide for crew chiefs of this event in future years, allowing us to remember what worked well and what didn't,
+                to avoid past mistakes, and to know what unexpected situations to look out for; and
+                2) to allow those who are responsible for billing this event to know what work was actually done and equipment was actually used,
+                so that the event can be billed accordingly.</p>
+
+                <p>Submit your crew chief report <a href="{% get_base_url %}{% url 'my:report' reminder.event.id %}">here</a>.</p>
+
+                <p>Submit crew hours <a href="{% get_base_url %}{% url 'my:hours-list' reminder.event.id %}">here</a>.</p>
+
+                <p>For your convenience, the Workorder PDF is attached.</p>
+
+                <p><b>{{ reminder.event }}</b><br>
+                <i>{{ reminder.event.location }}</i><br>
+                Start: {{ reminder.event.datetime_start }}<br>
+                End: {{ reminder.event.datetime_end }}<br>
+                Setup start: {{ reminder.setup_start }}<br>
+                Setup complete: {{ reminder.event.datetime_setup_complete }}</p>
+
+                <p>See full details of this event <a href="{% get_base_url %}{% url 'events:detail' reminder.event.id %}">here</a>.</p>
+                </div>
+            </td>
+        </tr>
+        <tr>
+            <td class="w960" width="960" height="10"></td>
+        </tr>
+        </tbody>
+</table>
+{% endblock %}

--- a/site_tmpl/emails/email_reportreminder.txt
+++ b/site_tmpl/emails/email_reportreminder.txt
@@ -1,0 +1,24 @@
+{% load tz %}
+{% load lnldb_tags %}
+{{ subject }}
+
+This is a reminder that you have a pending crew chief report for {{ reminder.event }}.
+
+Submitting a crew chief report and recording crew hours are required parts of being a crew chief. These tasks are expected to be completed shortly after an event while you still have all details of the event fresh in your mind. Delaying submitting your crew chief report directly delays the billing of this event.
+
+Crew chief reports exist for two purposes: 1) to serve as a guide for crew chiefs of this event in future years, allowing us to remember what worked well and what didn't, to avoid past mistakes, and to know what unexpected situations to look out for; and 2) to allow those who are responsible for billing this event to know what work was actually done and equipment was actually used, so that the event can be billed accordingly.
+
+Submit your crew chief report at {% get_base_url %}{% url 'my:report' reminder.event.id %}.
+
+Submit crew hours at {% get_base_url %}{% url 'my:hours-list' reminder.event.id %}.
+
+For your convenience, the Workorder PDF is attached.
+
+{{ reminder.event }}
+Location: {{ reminder.event.location }}
+Start: {{ reminder.event.datetime_start }}
+End: {{ reminder.event.datetime_end }}
+Setup start: {{ reminder.setup_start }}
+Setup complete: {{ reminder.event.datetime_setup_complete }}
+
+See full details of this event at {% get_base_url %}{% url 'events:detail' reminder.event.id %}.

--- a/site_tmpl/events.html
+++ b/site_tmpl/events.html
@@ -1,6 +1,7 @@
 {% extends 'base_admin.html' %}
 {% load get_attribute %}
 {% load append_get %}
+{% load permissionif %}
 {% block extras %}
 {% include 'js_event_checkboxes.tmpl' %}
 {% endblock %}
@@ -162,8 +163,12 @@
 
                         {% elif field.name == 'tasks' %}
                             <td class="tasks">
-                                <span class="crewtask"><a
-                                        href="{% url "events:add-crew" event.id %}">Crew</a></span>
+                                <span class="crewtask"><a href="{% url "events:add-crew" event.id %}">Crew</a></span>
+                                {% if event.approved and not event.reviewed %}
+                                    {% permission request.user has 'events.review_event' of event %}
+                                        <span class="remindtask"><a href="{% url "events:remindall" event.id %}?next={{ request.get_full_path }}">Remind</a></span>
+                                    {% endpermission %}
+                                {% endif %}
                             </td>
 
                         {% else %}


### PR DESCRIPTION
### Improve event submit, CC add, and report reminder emails
Greatly lengthen the event submit, CC add, and report reminder emails to include more information.
Add functionality to send CC report reminders to all CCs of an event who are missing reports at once. Add a button for this function to the 'tasks' column of the event lists.

### Make BCC actually mean BCC when sending emails
Previously, email addresses specified with bcc=[...] were actually cc'd rather than bcc'd.
I do not understand why that was ever done.

### Send an email when an event is edited
When an event is edited, send an email to that user and BCC the VP and the crew chiefs, the HP if the event has any projection either before or after the edits, and the Treasurer if the event had already been reviewed when the changes were made. The email states which fields of the event were changed, whether the event was approved or reviewed when the changes were made, and the name of the user who made the changes.
*This only applies to use of the Edit Event page, not any modifications to an event using other forms.*