### PR TITLE
Make capitalization on "my-" pages more consistent

### DIFF
--- a/site_tmpl/myevents.html
+++ b/site_tmpl/myevents.html
@@ -18,7 +18,7 @@
                         {% if instance.event.datetime_start > now %}
                             {{ instance.event.datetime_start|timeuntil }} from now
                         {% else %}
-                            {{ instance.event.datetime_start|timesince }} Ago
+                            {{ instance.event.datetime_start|timesince }} ago
                         {% endif %}
                     </td>
                     <td>{{ instance.event.location }}</td>
@@ -62,7 +62,7 @@
                         {% if instance.event.datetime_start > now %}
                             {{instance.event.datetime_start|timeuntil}} from now 
                         {% else %}
-                            {{instance.event.datetime_start|timesince}} Ago 
+                            {{instance.event.datetime_start|timesince}} ago 
                         {% endif %}
                     </td>
                     <td>{{instance.event.location}}</td>
@@ -97,7 +97,7 @@
                             {% if event.datetime_end > now %}
                                 {{event.datetime_end|timeuntil}} from now 
                             {% else %}
-                                {{event.datetime_end|timesince}} Ago 
+                                {{event.datetime_end|timesince}} ago 
                             {% endif %}
                         </td>
                         <td>{{event.location}}</td>
@@ -127,7 +127,7 @@
                             {% if event.datetime_end > now %}
                                 {{ event.datetime_end|timeuntil }} from now
                             {% else %}
-                                {{ event.datetime_end|timesince }} Ago
+                                {{ event.datetime_end|timesince }} ago
                             {% endif %}
                         </td>
                         <td>{{ event.location }}</td>

--- a/site_tmpl/mywo.html
+++ b/site_tmpl/mywo.html
@@ -19,7 +19,7 @@
         {% for event in events %}
             <tr class="info">
                 <td>{{event.event_name|public_field}}</td>
-                <td title="{{event.datetime_end}}">{{event.datetime_end|timesince}} Ago</td>
+                <td title="{{event.datetime_end}}">{{event.datetime_end|timesince}} ago</td>
                 <td>{{event.location}}</td>
                 <td>{{ event.status }}</td>
                 <td> 


### PR DESCRIPTION
Just noticed this.  Easy fix, in theory at least.

`4 months, 2 weeks Ago` -> `4 months, 2 weeks ago`


