### PR TITLE
Update display of Licensed projectionists in list

### DIFF
--- a/projection/views.py
+++ b/projection/views.py
@@ -47,7 +47,7 @@ def plist_detail(request):
     licensed = Q(pitinstances__pit_level__name_short__in=['PP', 'L'])
     alumni = Q(user__groups__name="Alumni")
 
-    context['unlicensed_users'] = users.exclude(licensed)
+    context['current_users'] = users.exclude(alumni)
     context['licensed_users'] = users.filter(licensed).exclude(alumni)
     context['alumni_users'] = users.filter(licensed).filter(alumni)
     context['levels'] = levels

--- a/site_tmpl/projectionlist.html
+++ b/site_tmpl/projectionlist.html
@@ -14,8 +14,6 @@
     <tr> 
         <th> User Name </th>
         <th> Class </th>
-        <th> License Expiry </th>
-        <th> License Number </th>
     </tr>
     {% for user in users %}
         {% if user.expired %}
@@ -36,12 +34,6 @@
                 </td>
                 <td>
                     {{ user.level.pit_level }}
-                </td>
-                <td>
-                    {{ user.license_expiry }}
-                </td>
-                <td>
-                    {{ user.license_number }}
                 </td>
             </tr>
     {% endfor %}

--- a/site_tmpl/projectionlist_detail.html
+++ b/site_tmpl/projectionlist_detail.html
@@ -46,7 +46,7 @@
     {% endfor %}
     
 </table>
-<h3> Licensed Projectionists </h3>
+<h3> Passed Practical Projectionists </h3>
 <ul>
 {% for user in licensed_users %}
     <li>

--- a/site_tmpl/projectionlist_detail.html
+++ b/site_tmpl/projectionlist_detail.html
@@ -10,7 +10,6 @@
     <a class="btn btn-info btn-lg" href="{% url "projection:pdf" %}"><i class="glyphicon glyphicon-print icon-white"></i>&nbsp;PDF</a>
 </div>
 <h2> {{ h2 }} </h2>
-<h3> Projectionists In Training </h3>
 <table class="table table-striped table-bordered table-condensed">
     <tr> 
         <th> User Name </th>
@@ -18,7 +17,7 @@
         <th> {{ level }} </th>
         {% endfor %}
     </tr>
-    {% for user in unlicensed_users %}
+    {% for user in current_users %}
         {% if user.expired %}
             <tr class="error" title="Expired"> 
         {% elif user.expiring %}
@@ -30,8 +29,14 @@
                 <td>
                     {% permission request.user has 'projection.edit_pits' %}
                         <a href="{% url "projection:edit" user.id %}">{{ user }}</a>
+                        {% if user in licensed_users %}
+                        <span class="label label-info">Licensed</span>
+                        {% endif %}
                     {% else %}
-                        {{ user }}
+                        {{ user }} 
+                        {% if user in licensed_users %}
+                        <span class="label label-info">Licensed</span>
+                        {% endif %}
                     {% endpermission %}
                 </td>
                 {% for level in levels %}
@@ -46,29 +51,7 @@
     {% endfor %}
     
 </table>
-<h3> Passed Practical Projectionists </h3>
-<ul>
-{% for user in licensed_users %}
-    <li>
-        {% permission request.user has 'projection.edit_pits' %}
-            <a href="{% url "projection:edit" user.id %}">{{ user }}</a>
-        {% else %}
-            {{ user }}
-        {% endpermission %}
 
-        {% if user.expired %}
-            <span class="badge badge-important" title="Expired">Expired</span>
-        {% elif user.expiring %}
-            <span class="badge badge-warning" title="Expiring Soon">Expiring Soon</span>
-        {% else %}
-            <span></span>
-        {% endif %}
-
-    
-    
-    </li>
-    {% endfor %}
-</ul>
 
 <h3> Alumni Projectionists </h3>
 <ul>


### PR DESCRIPTION
As stated in #515, LNL is now referring to members who complete the PIT
system as "Passed Practical" rather than "Licensed". This required
changing the "Projectionist List" page as well as the "Detailed
Projectionist" table to remove the appropriate fields.

Nothing has been removed from models, just in case this is something that
needs to be brought back in the future.

Closes #515 