### PR TITLE
Add feedback form link to Quick Links

### DIFF
--- a/site_tmpl/admin.html
+++ b/site_tmpl/admin.html
@@ -51,6 +51,7 @@
                         {% if request.user.is_superuser %}
                             <a class="btn btn-danger" href="../admin">Admin</a>
                         {% endif %}
+                        <a class="btn btn-success" href="https://forms.office.com/Pages/ResponsePage.aspx?id=9XacWBXK-UGIS1XsFaBnKsbZd_xTs0JLsg83YbwGk39UQ1BHSTdMR0RTVDlCWEM2M0hYOUtBWE5XUCQlQCN0PWcu">Feedback Form</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Provides easy access to the exec feedback form. 

Sharepoint does not show the link on mobile, so adding the link to the Quick Links will allow mobile users to access it.