### PR TITLE
Add New CC Resources to `CC Add` Email

### DIFF
--- a/events/signals.py
+++ b/events/signals.py
@@ -45,7 +45,12 @@ def email_cc_notification(sender, instance, created, raw=False, **kwargs):
         else:
             local_formatted = "a time of your choice "
 
-        e = CcAddEmailGenerator(ccinstance=i, attachments=attachments)
+        context = {
+                "is_new_cc": True if i.crew_chief.ccinstances == 1 else False
+                }
+
+        e = CcAddEmailGenerator(ccinstance=i, attachments=attachments,
+                context=context)
         e.send()
 
 

--- a/site_tmpl/emails/email_ccadd.html
+++ b/site_tmpl/emails/email_ccadd.html
@@ -43,11 +43,12 @@
 					<li>Technical Directior -
 						lnl-td@wpi.edu</li>
 					<li>Vice President - lnl-vp@wpi.edu</li>
+                    <li>Head Projectionist - lnl-hp@wpi.edu for a projection event</li>
 					<li>Events Office - 2nd floor of the
 						Campus Center, next to the
 						bookstore</li>
-					<li>25live - <a
-								     href="https://scheduling.wpi.edu">scheduling.wpi.edu</a>
+					<li>25Live - <a
+								     href="https://scheduling.wpi.edu">scheduling.wpi.edu</a> (Please reach out to an officer if you need to schedule an event with 25Live).
 		{% else %}
                 <p>If you have any questions or concerns about the above information, contact the Vice President at
                 <a href="mailto:lnl-vp@wpi.edu">lnl-vp@wpi.edu</a>.</p>

--- a/site_tmpl/emails/email_ccadd.html
+++ b/site_tmpl/emails/email_ccadd.html
@@ -32,9 +32,26 @@
                 <p>Submit your crew chief report <a href="{% get_base_url %}{% url 'my:report' ccinstance.event.id %}">here</a>.</p>
 
                 <p>Submit crew hours <a href="{% get_base_url %}{% url 'my:hours-list' ccinstance.event.id %}">here</a>.</p>
-
+		{% if is_new_cc %}
+			<p>By the way, congratualtions on your first event as
+			Crew Chief! Since this is your first time as a CC, here
+			are some helpful resources. 
+			<ul>
+					<li>Tech Bible -
+						<a
+								href="https://lnl.wpi.edu/tech-bible">lnl.wpi.edu/tech-bible</a></li>
+					<li>Technical Directior -
+						lnl-td@wpi.edu</li>
+					<li>Vice President - lnl-vp@wpi.edu</li>
+					<li>Events Office - 2nd floor of the
+						Campus Center, next to the
+						bookstore</li>
+					<li>25live - <a
+								     href="https://scheduling.wpi.edu">scheduling.wpi.edu</a>
+		{% else %}
                 <p>If you have any questions or concerns about the above information, contact the Vice President at
                 <a href="mailto:lnl-vp@wpi.edu">lnl-vp@wpi.edu</a>.</p>
+		{% endif %}
                 </div>
             </td>
         </tr>

--- a/site_tmpl/emails/email_ccadd.html
+++ b/site_tmpl/emails/email_ccadd.html
@@ -42,8 +42,8 @@
 								href="https://lnl.wpi.edu/bible">lnl.wpi.edu/bible</a></li>
 					<li>Technical Director -
 						<a href="mailto:lnl-td@wpi.edu">lnl-td@wpi.edu</a></li>
-					<li>Vice President - lnl-vp@wpi.edu</li>
-                    <li>Head Projectionist - lnl-hp@wpi.edu for a projection event</li>
+					<li>Vice President - <a href="mailto:lnl-vp@wpi.edu">lnl-vp@wpi.edu</a></li>
+                    <li>Head Projectionist - <a href="mailto:lnl-hp@wpi.edu">lnl-hp@wpi.edu</a> (for a projection event)</li>
 					<li>Events Office - 2nd floor of the
 						Campus Center, next to the
 						bookstore</li>

--- a/site_tmpl/emails/email_ccadd.html
+++ b/site_tmpl/emails/email_ccadd.html
@@ -39,7 +39,7 @@
 			<ul>
 					<li>Tech Bible -
 						<a
-								href="https://lnl.wpi.edu/tech-bible">lnl.wpi.edu/tech-bible</a></li>
+								href="https://lnl.wpi.edu/bible">lnl.wpi.edu/bible</a></li>
 					<li>Technical Directior -
 						lnl-td@wpi.edu</li>
 					<li>Vice President - lnl-vp@wpi.edu</li>

--- a/site_tmpl/emails/email_ccadd.html
+++ b/site_tmpl/emails/email_ccadd.html
@@ -40,8 +40,8 @@
 					<li>Tech Bible -
 						<a
 								href="https://lnl.wpi.edu/bible">lnl.wpi.edu/bible</a></li>
-					<li>Technical Directior -
-						lnl-td@wpi.edu</li>
+					<li>Technical Director -
+						<a href="mailto:lnl-td@wpi.edu">lnl-td@wpi.edu</a></li>
 					<li>Vice President - lnl-vp@wpi.edu</li>
                     <li>Head Projectionist - lnl-hp@wpi.edu for a projection event</li>
 					<li>Events Office - 2nd floor of the

--- a/site_tmpl/emails/email_ccadd.html
+++ b/site_tmpl/emails/email_ccadd.html
@@ -33,7 +33,7 @@
 
                 <p>Submit crew hours <a href="{% get_base_url %}{% url 'my:hours-list' ccinstance.event.id %}">here</a>.</p>
 		{% if is_new_cc %}
-			<p>By the way, congratualtions on your first event as
+			<p>By the way, congratulations on taking your first event as
 			Crew Chief! Since this is your first time as a CC, here
 			are some helpful resources. 
 			<ul>

--- a/site_tmpl/emails/email_ccadd.txt
+++ b/site_tmpl/emails/email_ccadd.txt
@@ -25,8 +25,9 @@ By the way, congratulations on taking your first event as Crew Chief! Since this
 • Tech Bible - https://lnl.wpi.edu/tech-bible
 • Technical Directior - mailto:lnl-td@wpi.edu
 • Vice President - mailto:lnl-vp@wpi.edu
+• Head Projectionist - mailto:lnl-hp@wpi.edu for a projection event
 • Events Office - 2nd floor of the Campus Center, next to the bookstore
-• 25live - https://scheduling.wpi.edu
+• 25live - https://scheduling.wpi.edu (Please reach out to an officer if you need to schedule an event with 25Live).
 {% else %}
 If you have any questions or concerns about the above information, contact the Vice President at mailto:lnl-vp@wpi.edu.
 {% endif %}

--- a/site_tmpl/emails/email_ccadd.txt
+++ b/site_tmpl/emails/email_ccadd.txt
@@ -21,7 +21,7 @@ Submit your crew chief report at {% get_base_url %}{% url 'my:report' ccinstance
 Submit crew hours at {% get_base_url %}{% url 'my:hours-list' ccinstance.event.id %}.
 
 {% if is_new_cc %}
-By the way, congratualtions on your first event asCrew Chief! Since this is your first time as a CC, here are some helpful resources. 
+By the way, congratulations on taking your first event as Crew Chief! Since this is your first time as a CC, here are some helpful resources. 
 • Tech Bible - https://lnl.wpi.edu/tech-bible
 • Technical Directior - mailto:lnl-td@wpi.edu
 • Vice President - mailto:lnl-vp@wpi.edu

--- a/site_tmpl/emails/email_ccadd.txt
+++ b/site_tmpl/emails/email_ccadd.txt
@@ -22,8 +22,8 @@ Submit crew hours at {% get_base_url %}{% url 'my:hours-list' ccinstance.event.i
 
 {% if is_new_cc %}
 By the way, congratulations on taking your first event as Crew Chief! Since this is your first time as a CC, here are some helpful resources. 
-• Tech Bible - https://lnl.wpi.edu/tech-bible
-• Technical Directior - mailto:lnl-td@wpi.edu
+• Tech Bible - https://lnl.wpi.edu/bible
+• Technical Director - mailto:lnl-td@wpi.edu
 • Vice President - mailto:lnl-vp@wpi.edu
 • Head Projectionist - mailto:lnl-hp@wpi.edu for a projection event
 • Events Office - 2nd floor of the Campus Center, next to the bookstore

--- a/site_tmpl/emails/email_ccadd.txt
+++ b/site_tmpl/emails/email_ccadd.txt
@@ -20,4 +20,13 @@ Submit your crew chief report at {% get_base_url %}{% url 'my:report' ccinstance
 
 Submit crew hours at {% get_base_url %}{% url 'my:hours-list' ccinstance.event.id %}.
 
-If you have any questions or concerns about the above information, contact the Vice President at lnl-vp@wpi.edu.
+{% if is_new_cc %}
+By the way, congratualtions on your first event asCrew Chief! Since this is your first time as a CC, here are some helpful resources. 
+• Tech Bible - https://lnl.wpi.edu/tech-bible
+• Technical Directior - mailto:lnl-td@wpi.edu
+• Vice President - mailto:lnl-vp@wpi.edu
+• Events Office - 2nd floor of the Campus Center, next to the bookstore
+• 25live - https://scheduling.wpi.edu
+{% else %}
+If you have any questions or concerns about the above information, contact the Vice President at mailto:lnl-vp@wpi.edu.
+{% endif %}


### PR DESCRIPTION
Provides additional resources to new CCs at the bottom of the `CC Add` email. 

Two questions:

- [ ] Should any additional resources be added?
- [ ] Should these resources be shown at the bottom of every `CC Add` email?

Resolves #544. This PR was a collaboration between myself and @Muirrum.