### PR TITLE
Add category label to member hours listing

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -119,7 +119,7 @@ class UserDetailView(mixins.HasPermOrTestMixin, generic.DetailView):
     def get_context_data(self, **kwargs):
         context = super(UserDetailView, self).get_context_data(**kwargs)
         context['u'] = u = self.object
-        context['hours'] = u.hours.filter(hours__isnull=False).select_related('event', 'service')
+        context['hours'] = u.hours.filter(hours__isnull=False).select_related('event', 'service','category')
         context['hour_total'] = u.hours.aggregate(hours=Sum('hours'))
         context['ccs'] = u.ccinstances.select_related('event').all()
 

--- a/site_tmpl/userdetail.html
+++ b/site_tmpl/userdetail.html
@@ -171,7 +171,7 @@
             <h3>Events Participated</h3>
             <ul class="list-unstyled">
                 {% for h in hours|dictsortreversed:"event.datetime_start" %}
-                    <li><a href="{% url "events:detail" h.event.id %}">{{ h.event }} {% if h.service %}({{ h.service.shortname }}){% elif h.category%}({{ h.category | lower}}){% endif %}</a> : {{ h.hours }}h ({{ h.event.datetime_start|date:'N d, Y' }})</li>
+                    <li><a href="{% url "events:detail" h.event.id %}">{{ h.event }} {% if h.service %}({{ h.service.shortname }}){% elif h.category%}({{ h.category }}){% endif %}</a> : {{ h.hours }}h ({{ h.event.datetime_start|date:'N d, Y' }})</li>
                 {% endfor %}
             </ul>
         </div>

--- a/site_tmpl/userdetail.html
+++ b/site_tmpl/userdetail.html
@@ -171,7 +171,7 @@
             <h3>Events Participated</h3>
             <ul class="list-unstyled">
                 {% for h in hours|dictsortreversed:"event.datetime_start" %}
-                    <li><a href="{% url "events:detail" h.event.id %}">{{ h.event }} {% if h.service %} ({{ h.service.shortname }}){% else %} (N/A){% endif %}</a> : {{ h.hours }}h ({{ h.event.datetime_start|date:'N d, Y' }})</li>
+                    <li><a href="{% url "events:detail" h.event.id %}">{{ h.event }} {% if h.service %}({{ h.service.shortname }}){% elif h.category%}({{ h.category | lower}}){% endif %}</a> : {{ h.hours }}h ({{ h.event.datetime_start|date:'N d, Y' }})</li>
                 {% endfor %}
             </ul>
         </div>


### PR DESCRIPTION
Adds category label to events in member detail page. In the example below, the top entry uses the 2019 event model and no category nor service was specified on checkout, the middle entry is a 2012 event model, and the bottom entry uses the 2019 event model.

![image](https://user-images.githubusercontent.com/15172054/139627437-a2afc2cc-1719-44b5-a031-57b7e8d125cd.png)

Fixes #563. /cc @Muirrum 