### PR TITLE
Fix question mark in CC report form

### DIFF
--- a/events/forms.py
+++ b/events/forms.py
@@ -743,7 +743,7 @@ class InternalReportForm(FieldAccessForm):
             HTML('<h4>What you might put in the report:</h4>'
                  '<ul><li>How was the event set up?</li>'
                  '<li>Roughly what equipment was used?</li>'
-                 '<li>Were there any last minute changes</li>'
+                 '<li>Were there any last minute changes?</li>'
                  '<li>Did you come across any issues?</li>'
                  '<li>Would you classify this event as the level it was booked under?</li>'
                  '<li>What information would be useful for somebody next year?</li></ul>'),


### PR DESCRIPTION
As revealed in WWW, this adds a missing question mark to the list of suggested questions when submitting a CC report.