### PR TITLE
Add `Add row` button to forms

### DIFF
--- a/events/views/flow.py
+++ b/events/views/flow.py
@@ -413,7 +413,7 @@ def hours_bulk_admin(request, id):
     context['event'] = event
     context['oldevent'] = isinstance(event, Event)
 
-    mk_hours_formset = inlineformset_factory(BaseEvent, Hours, extra=15, exclude=[])
+    mk_hours_formset = inlineformset_factory(BaseEvent, Hours, extra=3, exclude=[])
     mk_hours_formset.form = curry_class(MKHoursForm, event=event)
 
     if request.method == 'POST':
@@ -712,7 +712,7 @@ def assigncc(request, id):
     context['event'] = event
     context['oldevent'] = isinstance(event, Event)
 
-    cc_formset = inlineformset_factory(Event, EventCCInstance, extra=5, exclude=[])
+    cc_formset = inlineformset_factory(Event, EventCCInstance, extra=3, exclude=[])
     cc_formset.form = curry_class(CCIForm, event=event)
 
     if request.method == 'POST':

--- a/events/views/list.py
+++ b/events/views/list.py
@@ -952,7 +952,7 @@ def workshop_dates(request, pk):
     context = {}
     workshop = Workshop.objects.get(pk=pk)
     dates = WorkshopDate.objects.filter(workshop=workshop)
-    dates_formset = modelformset_factory(WorkshopDate, exclude=['workshop'], extra=5, can_delete=True,
+    dates_formset = modelformset_factory(WorkshopDate, exclude=['workshop'], extra=3, can_delete=True,
                                          form=WorkshopDatesForm)
     formset = dates_formset(queryset=dates)
 

--- a/events/views/my.py
+++ b/events/views/my.py
@@ -249,7 +249,7 @@ def hours_bulk(request, eventid):
 
     context['event'] = event
 
-    mk_event_formset = inlineformset_factory(Event, Hours, extra=15, exclude=[])
+    mk_event_formset = inlineformset_factory(Event, Hours, extra=3, exclude=[])
     mk_event_formset.form = curry_class(MKHoursForm, event=event)
 
     if request.method == 'POST':

--- a/site_tmpl/form_crispy_approval.html
+++ b/site_tmpl/form_crispy_approval.html
@@ -23,7 +23,7 @@
                                         <th class="col-xs-1">Delete</th>
                                     </tr>
                                 </thead>
-                                <tbody>
+                                <tbody id="form_data">
                                     {% for form in services_formset %}
                                         {% if form.errors %}
                                             <tr class="warning">
@@ -40,6 +40,7 @@
                                     {% endfor %}
                                 </tbody>
                             </table>
+                            <input type="button" class="btn btn-success" value="Add Row" id="add_form">
                         </div>
                     {% endif %}
                 </div>
@@ -49,6 +50,17 @@
             </form>
         </div>
     </div>
+    {% include "js_formset_add_row.tmpl" with formset=services_formset%}
+    {% with services_formset.empty_form as form %}
+        <table style="display:none;"> <tbody id="empty_form">
+                <tr>
+                    <td>{{ form.id }}{{ form.service }} </td>
+                    <td>{{ form.detail }} </td>
+                    <td>{{ form.DELETE }} </td>
+                </tr>
+            </tbody>
+        </table>
+    {% endwith %}
 {% endblock %}
 
 {% block extras %}

--- a/site_tmpl/form_crispy_event.html
+++ b/site_tmpl/form_crispy_event.html
@@ -32,7 +32,7 @@
                                         <th class="col-xs-1">Delete</th>
                                     </tr>
                                 </thead>
-                                <tbody>
+                                <tbody id="form_data">
                                     {% for form in services_formset %}
                                         {% if form.errors %}
                                             <tr class="warning">
@@ -49,6 +49,7 @@
                                     {% endfor %}
                                 </tbody>
                             </table>
+                            <input type="button" class="btn btn-success" value="Add Row" id="add_form">
                         </div>
                     {% endif %}
                 </div>
@@ -58,6 +59,17 @@
             </form>
         </div>
     </div>
+    {% include "js_formset_add_row.tmpl" with formset=services_formset%}
+    {% with services_formset.empty_form as form %}
+        <table style="display:none;"> <tbody id="empty_form">
+                <tr>
+                    <td>{{ form.id }}{{ form.service }} </td>
+                    <td>{{ form.detail }} </td>
+                    <td>{{ form.DELETE }} </td>
+                </tr>
+            </tbody>
+        </table>
+    {% endwith %}
 {% endblock %}
 
 {% block extras %}

--- a/site_tmpl/form_crispy_projection.html
+++ b/site_tmpl/form_crispy_projection.html
@@ -16,7 +16,7 @@
                 <div>
                 {% endif %}
 					{{ formset.management_form }}
-					<table class="table table-striped" valign="top">
+					<table class="table table-striped" valign="top"><tbody id="form_data">
 						<tr>
 							<th>PIT Level</th>
 							<th>Created On </th>
@@ -40,17 +40,30 @@
 							<td>{{ form.DELETE }} </td>
 						</tr>
 					{% endfor %}
-					</table>
+					</tbody></table>
 					<p class="text-muted">Pressing 'Delete This User' below will delete all of the information you see on this page and
 					the user will no longer be listed in the projectionist list.</p>
 					<div class="form-actions">
 						<input name="submit" value="Save changes" class="btn btn-primary" id="submit-id-save" type="submit"> 
+						<input type="button" class="btn btn-success" value="Add Row" id="add_form">
 						{% if pk %}<a class="btn btn-danger" href="{% url "projection:remove" pk %}">Delete This User</a> {% endif %}
 					</div>
 				</div>
             </form>
         </div>
     </div>
+    {% include "js_formset_add_row.tmpl" %}
+    {% with formset.empty_form as form %}
+        <table style="display:none;"> <tbody id="empty_form">
+                <tr>
+					<td>{{ form.id }}{{ form.pit_level }} </td>
+					<td>{{ form.created_on }} </td>
+					<td>{{ form.valid }} </td>
+					<td>{{ form.DELETE }} </td>
+				</tr>
+            </tbody>
+        </table>
+    {% endwith %}
 {% endblock %}
 
 {% block extras %}

--- a/site_tmpl/formset_crispy_arbitrary.html
+++ b/site_tmpl/formset_crispy_arbitrary.html
@@ -8,7 +8,7 @@
                 <form method="post" action="" class="form-inline" enctype="multipart/form-data">
                 {% csrf_token %}
                 {{ formset.management_form }}
-                <table class="table table-striped" valign="top">
+                <table class="table table-striped" valign="top"> <tbody id="form_data">
                     <tr>
                         <th>Name</th>
                         <th>Value </th>
@@ -32,13 +32,26 @@
                         <td>{{ form.DELETE }} </td>
                     </tr>
                 {% endfor %}
-                </table>
+                </tbody></table>
                 
-                <div class="form-actions"><input name="save" value="Save Changes" class="btn btn-primary" id="submit-id-save" type="submit"> </div>
+                <div class="form-actions"><input name="save" value="Save Changes" class="btn btn-primary" id="submit-id-save" type="submit">
+                <input type="button" class="btn btn-success" value="Add Row" id="add_form"></div>
                 </form>
                 
         </div>
     </div>
+    {% include "js_formset_add_row.tmpl" %}
+    {% with formset.empty_form as form %}
+        <table style="display:none;"> <tbody id="empty_form">
+                <tr>
+                    <td>{{ form.id }}{{ form.key_name }} </td>
+                    <td>{{ form.key_value }} </td>
+                    <td>{{ form.key_quantity }} </td>
+                    <td>{{ form.DELETE }} </td>
+                </tr>
+            </tbody>
+        </table>
+    {% endwith %}
 {% endblock %}
 
 {% block extras %}

--- a/site_tmpl/formset_crispy_attachments.html
+++ b/site_tmpl/formset_crispy_attachments.html
@@ -8,7 +8,7 @@
                 <form method="post" action="" class="form-inline" enctype="multipart/form-data">
                 {% csrf_token %}
                 {{ formset.management_form }}
-                <table class="table table-striped" valign="top">
+                <table class="table table-striped" valign="top"> <tbody id="form_data">
                     <tr>
                         <th>For Service </th>
                         <th>Attachment </th>
@@ -31,13 +31,26 @@
                         <td>{{ form.DELETE }} </td>
                     </tr>
                 {% endfor %}
-                </table>
+                </tbody></table>
                 
-                <div class="form-actions"><input name="save" value="Save Changes" class="btn btn-primary" id="submit-id-save" type="submit"> </div>
+                <div class="form-actions"><input name="save" value="Save Changes" class="btn btn-primary" id="submit-id-save" type="submit"> 
+                <input type="button" class="btn btn-success" value="Add Row" id="add_form"></div>
                 </form>
                 
         </div>
     </div>
+    {% include "js_formset_add_row.tmpl" %}
+    {% with formset.empty_form as form %}
+        <table style="display:none;"> <tbody id="empty_form">
+                <tr>
+                    <td>{{ form.id }}{{ form.for_service }}{{form.externally_uploaded}} </td>
+                    <td>{{ form.attachment }} </td>
+                    <td>{{ form.note }}</td>
+                    <td>{{ form.DELETE }} </td>
+                </tr>
+            </tbody>
+        </table>
+    {% endwith %}
 {% endblock %}
 
 {% block extras %}

--- a/site_tmpl/formset_crispy_extras.html
+++ b/site_tmpl/formset_crispy_extras.html
@@ -8,7 +8,7 @@
                 <form method="post" action="" class="form-inline" enctype="multipart/form-data">
                 {% csrf_token %}
                 {{ formset.management_form }}
-                <table class="table table-striped" valign="top">
+                <table class="table table-striped" valign="top"> <tbody id="form_data">
                     <tr>
                         <th>Extra</th>
                         <th>Quantity </th>
@@ -28,13 +28,24 @@
                         <td>{{ form.DELETE }} </td>
                     </tr>
                 {% endfor %}
-                </table>
+                </tbody></table>
                 
-                <div class="form-actions"><input name="save" value="Save Changes" class="btn btn-primary" id="submit-id-save" type="submit"> </div>
+                <div class="form-actions"><input name="save" value="Save Changes" class="btn btn-primary" id="submit-id-save" type="submit">
+                <input type="button" class="btn btn-success" value="Add Row" id="add_form"></div>
                 </form>
                 
         </div>
     </div>
+{% include "js_formset_add_row.tmpl" %}
+    {% with formset.empty_form as form %}
+        <table style="display:none;"> <tbody id="empty_form">
+            <tr>
+                <td>{{ form.id }}{{ form.extra }} </td>
+                <td>{{ form.quant }} </td>
+                <td>{{ form.DELETE }} </td>
+            </tr>
+        </tbody> </table>
+    {% endwith %}
 {% endblock %}
 
 {% block extras %}

--- a/site_tmpl/formset_crispy_helpers.html
+++ b/site_tmpl/formset_crispy_helpers.html
@@ -8,7 +8,7 @@
                 <form method="post" action="" class="form-inline">
                 {% csrf_token %}
                 {{ formset.management_form }}
-                <table class="table table-striped" valign="top">
+                <table class="table table-striped" valign="top"> <tbody id="form_data">
                     <tr>
                         <th>Setup Location </th>
                         <th>Setup Time </th>
@@ -46,13 +46,30 @@
                         <td>{{ form.DELETE }} </td>
                     </tr>
                 {% endfor %}
-                </table>
+                </tbody></table>
                 
-                <div class="form-actions"><input name="save" value="Save changes" class="btn btn-primary" id="submit-id-save" type="submit"> </div>
+                <div class="form-actions"><input name="save" value="Save changes" class="btn btn-primary" id="submit-id-save" type="submit">
+                <input type="button" class="btn btn-success" value="Add Row" id="add_form"></div>
                 </form>
                 
         </div>
     </div>
+{% include "js_formset_add_row.tmpl" %}
+    {% with formset.empty_form as form %}
+        <table style="display:none;"> <tbody id="empty_form">
+            <tr>
+                <td>{{ form.id }}{{ form.setup_location }} </td>
+                <td class="dtptable">{{ form.setup_start }} </td>
+                {% if oldevent %}
+                    <td>{{ form.service }}</td>
+                {% else %}
+                    <td>{{ form.category }}</td>
+                {% endif %}
+                <td>{{ form.crew_chief }} </td>
+                <td>{{ form.DELETE }} </td>
+            </tr>
+        </tbody> </table>
+    {% endwith %}
 {% endblock %}
 
 {% block extras %}

--- a/site_tmpl/formset_generic.html
+++ b/site_tmpl/formset_generic.html
@@ -15,7 +15,7 @@
             <form method="post" action="" class="form-inline" enctype="multipart/form-data">
                 {% csrf_token %}
                 {{ formset.management_form }}
-                <table class="table table-striped" valign="top">
+                <table class="table table-striped" valign="top"><tbody id="form_data">
                     <tr>
                     {% for field in formset.forms.0 %}
                         {% if field.label and not field.is_hidden %}
@@ -39,11 +39,24 @@
                             {{ hidden }}
                         {% endfor %}
                     {% endfor %}
-                </table>
-                <div class="form-actions"><input name="save" value="Save Changes" class="btn btn-primary" id="submit-id-save" type="submit"> </div>
+                </tbody></table>
+                <div class="form-actions"><input name="save" value="Save Changes" class="btn btn-primary" id="submit-id-save" type="submit"> 
+                <input type="button" class="btn btn-success" value="Add Row" id="add_form"></div>
             </form>
         </div>
     </div>
+    {% include "js_formset_add_row.tmpl" %}
+    {% with formset.empty_form as form %}
+        <table style="display:none;"> <tbody id="empty_form">
+            <tr>
+                {% for field in form %}
+                    {% if field.label and not field.is_hidden %}
+                        <td>{{ field|as_crispy_field }}</td>
+                    {% endif %}
+                {% endfor %}
+            </tr>
+        </tbody> </table>
+    {% endwith %}
 {% endblock %}
 
 {% block finalsay %}

--- a/site_tmpl/formset_hours_bulk.html
+++ b/site_tmpl/formset_hours_bulk.html
@@ -8,7 +8,7 @@
                 <form method="post" action="" class="form-inline" enctype="multipart/form-data">
                 {% csrf_token %}
                 {{ formset.management_form }}
-                <table class="table table-striped" valign="top">
+                <table class="table table-striped" valign="top"> <tbody id="form_data">
                     <tr>
                         <th>User </th>
                         <th>Hours </th>
@@ -46,13 +46,28 @@
                         <td>{{ form.DELETE }} </td>
                     </tr>
                 {% endfor %}
-                </table>
-                
-                <div class="form-actions"><input name="save" value="Save Changes" class="btn btn-primary" id="submit-id-save" type="submit"> </div>
+                </tbody></table>
+                <div class="form-actions"><input name="save" value="Save Changes" class="btn btn-primary" id="submit-id-save" type="submit">
+                <input type="button" class="btn btn-success" value="Add Row" id="add_form"></div>
                 </form>
                 
         </div>
     </div>
+    {% include "js_formset_add_row.tmpl" %}
+    {% with formset.empty_form as form %}
+        <table style="display:none;"> <tbody id="empty_form">
+            <tr>
+                <td>{{ form.id }}{{ form.user }}</td>
+                <td>{{ form.hours }} </td>
+                {% if oldevent %}
+                    <td>{{ form.service }}</td>
+                {% else %}
+                    <td>{{ form.category }}</td>
+                {% endif %}
+                <td>{{ form.DELETE }} </td>
+            </tr>
+        </tbody> </table>
+    {% endwith %}
 {% endblock %}
 
 {% block extras %}

--- a/site_tmpl/formset_office_hour_updates.html
+++ b/site_tmpl/formset_office_hour_updates.html
@@ -8,7 +8,7 @@
                 <form method="post" action="" class="form" enctype="multipart/form-data">
                 {% csrf_token %}
                 {{ formset.management_form }}
-                <table class="table table-striped" valign="top">
+                <table class="table table-striped" valign="top"><tbody id="form_data">
                     <tr>
                         <th>Message </th>
                         <th>Expires </th>
@@ -36,9 +36,9 @@
                         {{ hidden }}
                     {% endfor %}
                 {% endfor %}
-                </table>
-                
-                <div class="form-actions"><input name="save" value="Save Changes" class="btn btn-primary" id="submit-id-save" type="submit"> </div>
+                </tbody></table>
+                <div class="form-actions"><input name="save" value="Save Changes" class="btn btn-primary" id="submit-id-save" type="submit">
+                <input type="button" class="btn btn-success" value="Add Row" id="add_form"></div>
                 </form>
                 <script>
                     $("[id*='expires_0']").datepicker({
@@ -54,6 +54,17 @@
                 </script>
         </div>
     </div>
+    {% include "js_formset_add_row.tmpl" %}
+    {% with formset.empty_form as form %}
+        <table style="display:none;"> <tbody id="empty_form">
+                <tr>
+                    <td>{{ form.message }}</td>
+                    <td>{{ form.expires }} </td>
+                    <td>{{ form.DELETE }} </td>
+                </tr>
+            </tbody>
+        </table>
+    {% endwith %}
 {% endblock %}
 
 {% block extras %}

--- a/site_tmpl/formset_workshop_dates.html
+++ b/site_tmpl/formset_workshop_dates.html
@@ -8,7 +8,7 @@
                 <form method="post" action="" class="form-inline" enctype="multipart/form-data">
                 {% csrf_token %}
                 {{ formset.management_form }}
-                <table class="table table-striped" valign="top">
+                <table class="table table-striped" valign="top"><tbody id="form_data">
                     <tr>
                         <th>Date </th>
                         <th>Delete?</th>
@@ -33,9 +33,10 @@
                         {{ hidden }}
                     {% endfor %}
                 {% endfor %}
-                </table>
+                </tbody></table>
                 
-                <div class="form-actions"><input name="save" value="Save Changes" class="btn btn-primary" id="submit-id-save" type="submit"> </div>
+                <div class="form-actions"><input name="save" value="Save Changes" class="btn btn-primary" id="submit-id-save" type="submit">
+                <input type="button" class="btn btn-success" value="Add Row" id="add_form"></div>
                 </form>
                 <script>
                     $("[id*='date_0']").datepicker({
@@ -51,6 +52,16 @@
                 </script>
         </div>
     </div>
+    {% include "js_formset_add_row.tmpl" %}
+    {% with formset.empty_form as form %}
+        <table style="display:none;"> <tbody id="empty_form">
+                <tr>
+                    <td>{{ form.date }}</td>
+                    <td>{{ form.DELETE }} </td>
+                </tr>
+            </tbody>
+        </table>
+    {% endwith %}
 {% endblock %}
 
 {% block extras %}

--- a/site_tmpl/js_formset_add_row.tmpl
+++ b/site_tmpl/js_formset_add_row.tmpl
@@ -1,0 +1,31 @@
+<script>
+    function add_form(){
+        var form_idx = $('#id_{{formset.prefix}}-TOTAL_FORMS').val();
+        $('#form_data').append($('#empty_form').html().replace(/__prefix__/g, form_idx));
+        // console.log('Adding field ' + form_idx);
+        $('#id_{{formset.prefix}}-TOTAL_FORMS').val(parseInt(form_idx) + 1);
+        $('#form_data>tr:last-child>td:first').find('input[type=text]').focus();
+
+
+        // Adds datepicker/timepicker popup for forms which contain date/time fields
+        $(".dateinput").datepicker({
+                    format: 'yyyy-mm-dd',
+                    clearBtn: true,
+                    todayBtn: true,
+                    todayHighlight: true,
+                    orientation: 'top'
+                });
+        $(".timeinput").timepicker({
+                    minuteStep: 1,
+                    showInputs: true,
+                    defaultTime: '',
+                    showMeridian: true
+                });
+    }
+    $('#add_form').click(function() {
+        add_form();
+    });
+    $('.table').keypress(function(e) {
+        if (e.which == 13) { add_form();}
+    });
+</script>


### PR DESCRIPTION
Adds a green `Add Row` button to the right (or occasionally above) the submit button in forms where lots of extras are currently displayed. This reduces the visual clutter of lots of empty extra form rows and also allows users to input lots of data without submitting the form multiple times.

To add a new row, the `Return` or `Enter` button can be pressed or the green `Add Row` button can be clicked.

Todo:
- [x] Change all forms to only have 1-3 extra form rows by default