### PR TITLE
Add Meetings in progress to list view

### DIFF
--- a/meetings/views.py
+++ b/meetings/views.py
@@ -211,9 +211,10 @@ def listattendance(request, page=1):
     except InvalidPage:
         future_mtgs = paginated.page(1)
 
-    context['lists'] = [("Meetings In Progress", inprogress_mtgs),
-                        ("Past Meetings", past_mtgs),
+    context['lists'] = [("Past Meetings", past_mtgs),
                         ("Future Meetings", future_mtgs)]
+    if len(inprogress_mtgs) > 0:
+        context['lists'].insert(0, ("In Progress Meetings", inprogress_mtgs))
     return render(request, 'meeting_list.html', context)
 
 

--- a/meetings/views.py
+++ b/meetings/views.py
@@ -214,7 +214,7 @@ def listattendance(request, page=1):
     context['lists'] = [("Past Meetings", past_mtgs),
                         ("Future Meetings", future_mtgs)]
     if len(inprogress_mtgs) > 0:
-        context['lists'].insert(0, ("In Progress Meetings", inprogress_mtgs))
+        context['lists'].insert(0, ("Meetings In Progress", inprogress_mtgs))
     return render(request, 'meeting_list.html', context)
 
 

--- a/meetings/views.py
+++ b/meetings/views.py
@@ -4,6 +4,7 @@ from django.contrib.auth.decorators import login_required, permission_required
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import InvalidPage, Paginator
 from django.db.models.aggregates import Count
+from django.db.models import F
 from django.views.generic.edit import DeleteView
 from django.forms.models import inlineformset_factory
 from django.http import HttpResponseRedirect, HttpResponse
@@ -190,10 +191,10 @@ def listattendance(request, page=1):
     mtgs = Meeting.objects \
         .select_related('meeting_type') \
         .annotate(num_attendsees=Count('attendance'))
-    inprogress_mtgs = mtgs.filter(datetime__gte=datetime.datetime.now() - datetime.timedelta(minutes=65)) \
-        .filter(datetime__lte=datetime.datetime.now() + datetime.timedelta(minutes=65)) \
+    inprogress_mtgs = mtgs.filter(datetime__lte=timezone.now()) \
+        .filter(datetime__gte=timezone.now() - F('duration') - datetime.timedelta(minutes=5)) \
         .order_by('-datetime')
-    past_mtgs = mtgs.filter(datetime__lte=datetime.datetime.now()) \
+    past_mtgs = mtgs.filter(datetime__lte=timezone.now() - F('duration') - datetime.timedelta(minutes=5)) \
         .order_by('-datetime')
     future_mtgs = mtgs.filter(datetime__gte=timezone.now()) \
         .order_by('datetime')

--- a/meetings/views.py
+++ b/meetings/views.py
@@ -190,7 +190,10 @@ def listattendance(request, page=1):
     mtgs = Meeting.objects \
         .select_related('meeting_type') \
         .annotate(num_attendsees=Count('attendance'))
-    past_mtgs = mtgs.filter(datetime__lte=timezone.now()) \
+    inprogress_mtgs = mtgs.filter(datetime__gte=datetime.datetime.now() - datetime.timedelta(minutes=65)) \
+        .filter(datetime__lte=datetime.datetime.now() + datetime.timedelta(minutes=65)) \
+        .order_by('-datetime')
+    past_mtgs = mtgs.filter(datetime__lte=datetime.datetime.now()) \
         .order_by('-datetime')
     future_mtgs = mtgs.filter(datetime__gte=timezone.now()) \
         .order_by('datetime')
@@ -207,7 +210,8 @@ def listattendance(request, page=1):
     except InvalidPage:
         future_mtgs = paginated.page(1)
 
-    context['lists'] = [("Past Meetings", past_mtgs),
+    context['lists'] = [("Meetings In Progress", inprogress_mtgs),
+                        ("Past Meetings", past_mtgs),
                         ("Future Meetings", future_mtgs)]
     return render(request, 'meeting_list.html', context)
 

--- a/site_tmpl/meeting_list.html
+++ b/site_tmpl/meeting_list.html
@@ -22,6 +22,7 @@
                 </tr>
                 {% endfor %}
             </table>
+            {% if name != "Meetings In Progress" %}
             <ul class="pager">
 
                 {% if mtgs.has_previous %}
@@ -50,6 +51,7 @@
                 </li>
 
             </ul>
+            {% endif %}
             </div>
         </div>
     {% endfor %}


### PR DESCRIPTION
Adds a new section at the top of the meeting list page to show meetings in progress. This can help users find the details, minutes, and et cetera. Currently, in-progress meetings are sorted into `past` which doesn't quite make sense when looking for an in-progress meeting.

Closes #574.

Todo:
- [x] Fix duration math (currently set to static 65 min for testing)
- [x] Hide section on page when no meetings are in progress