### PR TITLE
Fix: Order of events in lists

### DIFF
--- a/events/views/list.py
+++ b/events/views/list.py
@@ -464,8 +464,8 @@ def unreviewed(request, start=None, end=None):
 
     now = datetime.datetime.now(pytz.utc)
     events = BaseEvent.objects.filter(approved=True, closed=False, cancelled=False).filter(reviewed=False)\
-        .filter(datetime_end__lte=now).order_by('datetime_start').distinct()
-    events, context = filter_events(request, context, events, start, end, prefetch_cc=True)
+        .filter(datetime_end__lte=now).distinct()
+    events, context = filter_events(request, context, events, start, end, prefetch_cc=True, sort='datetime_start')
 
     context['h2'] = "Events Pending Billing Review"
     context['events'] = events
@@ -514,10 +514,8 @@ def unbilled(request, start=None, end=None):
         return build_redirect(request, projection=request.COOKIES['projection'], **request.GET.dict())
 
     events = BaseEvent.objects.filter(closed=False).filter(reviewed=True)\
-        .filter(billings__isnull=True, multibillings__isnull=True).filter(billed_in_bulk=False)\
-        .order_by('datetime_start').distinct()
-    events, context = filter_events(request, context, events, start, end, prefetch_billing=True)
-
+        .filter(billings__isnull=True, multibillings__isnull=True).filter(billed_in_bulk=False).distinct()
+    events, context = filter_events(request, context, events, start, end, prefetch_billing=True, sort='datetime_start')
     context['h2'] = "Events to be Billed"
     context['events'] = events
     context['baseurl'] = reverse("events:unbilled")
@@ -564,9 +562,8 @@ def unbilled_semester(request, start=None, end=None):
         return build_redirect(request, projection=request.COOKIES['projection'], **request.GET.dict())
 
     events = BaseEvent.objects.filter(closed=False).filter(reviewed=True)\
-        .filter(billings__isnull=True, multibillings__isnull=True).filter(billed_in_bulk=True)\
-        .order_by('datetime_start').distinct()
-    events, context = filter_events(request, context, events, start, end, prefetch_billing=True)
+        .filter(billings__isnull=True, multibillings__isnull=True).filter(billed_in_bulk=True).distinct()
+    events, context = filter_events(request, context, events, start, end, prefetch_billing=True, sort='datetime_start')
 
     context['h2'] = "Events to be Billed in Bulk"
     context['events'] = events
@@ -664,8 +661,8 @@ def unpaid(request, start=None, end=None):
         .filter(Q(billings__isnull=False) | Q(multibillings__isnull=False)).exclude(closed=True)\
         .exclude(numpaid__gt=0).filter(reviewed=True) \
         .exclude(billings__isnull=False, Event2019___workday_fund__isnull=False, Event2019___worktag__isnull=False) \
-        .exclude(billings__isnull=False, Event2019___entered_into_workday=True).order_by('datetime_start').distinct()
-    events, context = filter_events(request, context, events, start, end, prefetch_billing=True)
+        .exclude(billings__isnull=False, Event2019___entered_into_workday=True).distinct()
+    events, context = filter_events(request, context, events, start, end, prefetch_billing=True, sort='datetime_start')
 
     context['h2'] = "Pending Payments"
     context['events'] = events
@@ -752,9 +749,8 @@ def unpaid_workday(request, start=None, end=None):
         return build_redirect(request, projection=request.COOKIES['projection'], **request.GET.dict())
 
     events = Event2019.objects.annotate(numpaid=Count('billings__date_paid')+Count('multibillings__date_paid')) \
-        .filter(closed=False, reviewed=True, entered_into_workday=True).exclude(numpaid__gt=0)\
-        .order_by('datetime_start').distinct()
-    events, context = filter_events(request, context, events, start, end, prefetch_org=True, event2019=True)
+        .filter(closed=False, reviewed=True, entered_into_workday=True).exclude(numpaid__gt=0).distinct()
+    events, context = filter_events(request, context, events, start, end, prefetch_org=True, event2019=True, sort='datetime_start')
 
     context['h2'] = "Pending Workday ISDs"
     context['events'] = events

--- a/events/views/list.py
+++ b/events/views/list.py
@@ -411,7 +411,7 @@ def findchief(request, start=None, end=None):
         .filter(Q(Event___ccs_needed__gt=F('num_ccs')) |
                 Q(num_ccs__lt=Count('serviceinstance__service__category', distinct=True))).distinct()
 
-    events, context = filter_events(request, context, events, start, end, prefetch_cc=True)
+    events, context = filter_events(request, context, events, start, end, prefetch_cc=True, sort='datetime_start')
 
     context['h2'] = "Needs a Crew Chief"
     context['takes_param_projection'] = True

--- a/events/views/list.py
+++ b/events/views/list.py
@@ -151,7 +151,7 @@ def build_redirect(request, **kwargs):
 
 
 def filter_events(request, context, events, start, end, prefetch_org=False, prefetch_cc=False, prefetch_billing=False,
-                  hide_unapproved=False, event2019=False):
+                  hide_unapproved=False, event2019=False, sort='-datetime_start'):
     """
     Filter a queryset of events based on specified criteria
 
@@ -167,6 +167,7 @@ def filter_events(request, context, events, start, end, prefetch_org=False, pref
     related items based on building
     :param hide_unapproved: Boolean - If true, exclude events that have not been approved
     :param event2019: Boolean - If true, queryset only contains Event2019 objects
+    :param sort: String - Default field to sort by (prepend "-" for reverse)
     :returns: Queryset of events and updated context dictionary
     """
     if not request.user.has_perm('events.view_hidden_event'):
@@ -205,7 +206,7 @@ def filter_events(request, context, events, start, end, prefetch_org=False, pref
     events, context = datefilter(events, context, start, end)
 
     page = request.GET.get('page')
-    sort = request.GET.get('sort') or '-datetime_start'
+    sort = request.GET.get('sort') or sort
     events = paginate_helper(events, page, sort)
     return events, context
 

--- a/events/views/list.py
+++ b/events/views/list.py
@@ -208,6 +208,8 @@ def filter_events(request, context, events, start, end, prefetch_org=False, pref
     page = request.GET.get('page')
     sort = request.GET.get('sort') or sort
     events = paginate_helper(events, page, sort)
+    context['pagninate_next_label'] = "Older" if '-datetime_start' in sort else "Newer"
+    context['pagninate_last_label'] = "Newer" if '-datetime_start' in sort else "Older"                                                                 
     return events, context
 
 

--- a/events/views/list.py
+++ b/events/views/list.py
@@ -265,7 +265,7 @@ def upcoming(request, start=None, end=None):
         return build_redirect(request, projection=request.COOKIES['projection'], **request.GET.dict())
 
     events = BaseEvent.objects.filter(Q(approved=True) & Q(closed=False) & Q(cancelled=False)).distinct()
-    events, context = filter_events(request, context, events, start, end, prefetch_cc=True)
+    events, context = filter_events(request, context, events, start, end, prefetch_cc=True, sort='datetime_start')
 
     context['h2'] = "Upcoming Events"
     context['events'] = events
@@ -308,7 +308,7 @@ def incoming(request, start=None, end=None):
         return build_redirect(request, projection=request.COOKIES['projection'], **request.GET.dict())
 
     events = BaseEvent.objects.filter(approved=False).exclude(Q(closed=True) | Q(cancelled=True)).distinct()
-    events, context = filter_events(request, context, events, start, end)
+    events, context = filter_events(request, context, events, start, end, sort='datetime_start')
 
     context['h2'] = "Incoming Events"
     context['events'] = events
@@ -356,7 +356,7 @@ def openworkorders(request, start=None, end=None):
         return build_redirect(request, projection=request.COOKIES['projection'], **request.GET.dict())
 
     events = BaseEvent.objects.filter(approved=True, closed=False, cancelled=False).distinct()
-    events, context = filter_events(request, context, events, start, end, prefetch_billing=True)
+    events, context = filter_events(request, context, events, start, end, prefetch_billing=True, sort='datetime_start')
 
     context['h2'] = "Open Events"
     context['events'] = events
@@ -711,7 +711,7 @@ def awaitingworkday(request, start=None, end=None):
         .filter(reviewed=True, billings__isnull=False, workday_fund__isnull=False, worktag__isnull=False,
                 entered_into_workday=False) \
         .exclude(Q(billings__date_paid__isnull=False) | Q(multibillings__date_paid__isnull=False)).distinct()
-    events, context = filter_events(request, context, events, start, end, prefetch_billing=True, event2019=True)
+    events, context = filter_events(request, context, events, start, end, prefetch_billing=True, event2019=True, sort='datetime_start')
 
     context['h2'] = "Events to Enter Into Workday"
     context['events'] = events

--- a/site_tmpl/events.html
+++ b/site_tmpl/events.html
@@ -247,10 +247,10 @@
     <ul class="pager">
         {% if events.has_previous %}
             <li class="previous">
-            <a href="{% append_to_get page=events.previous_page_number %}">&larr; Newer</a>
+            <a href="{% append_to_get page=events.previous_page_number %}">&larr; {%if pagninate_last_label %}{{pagninate_last_label}}{% else %}Newer{% endif %}</a>
         {% else %}
             <li class="previous disabled">
-            <a href="#" >&larr; Newer</a>
+            <a href="#" >&larr; {%if pagninate_last_label %}{{pagninate_last_label}}{% else %}Newer{% endif %}</a>
         {% endif %}
         
         </li>
@@ -260,10 +260,10 @@
         
         {% if events.has_next %}
             <li class="next">
-            <a href="{% append_to_get page=events.next_page_number %}">Older &rarr;</a>
+            <a href="{% append_to_get page=events.next_page_number %}">{%if pagninate_next_label %}{{pagninate_next_label}}{% else %}Older{% endif %} &rarr;</a>
         {% else %}
             <li class="next disabled">
-            <a href="#">Older &rarr;</a>
+            <a href="#">{%if pagninate_next_label %}{{pagninate_next_label}}{% else %}Older{% endif %} &rarr;</a>
         {% endif %}
         </li>
     </ul>


### PR DESCRIPTION
Several lists of events (`unreviewed`, `unbilled`, `unbilled_semester`, `unpaid`, and `unpaid_workday`) were ordered by newest-first, but the ordering was overridden to oldest-first. This PR sorts these lists as they were once sorted.

Additionally, the lists 'needcc', `upcoming`, `incoming`, `openworkorders`, and `awaitingworkday` are now ordered by event start time, earliest-first.

[An example](https://github.com/Muirrum/lnldb/blob/7cfbb55bcd92447c48c6e38cf208ff22aaf30a1f/events/views/list.py#L665): This instance was not sorted previously because the function `filter_events` resorts the list by `-datetime_start`. Adding a `sort` parameter with `datetime_start` sorts the list in the intended direction.

```diff
events = BaseEvent.objects.filter(approved=True, closed=False, cancelled=False).filter(reviewed=False)\
-        .filter(datetime_end__lte=now).order_by('datetime_start').distinct()
-    events, context = filter_events(request, context, events, start, end, prefetch_cc=True)
+        .filter(datetime_end__lte=now).distinct()
+    events, context = filter_events(request, context, events, start, end, prefetch_cc=True, sort='datetime_start')