### PR TITLE
fix: name pdf with invoice type (quote or bill)

### DIFF
--- a/pdfs/views.py
+++ b/pdfs/views.py
@@ -175,8 +175,10 @@ def generate_event_bill_pdf(request, event):
     data['events_data'] = [event_data]
 
     resp = generate_pdf(data, 'pdf_templates/bill-itemized.html', request)
-
-    resp['Content-Disposition'] = 'inline; filename="%s-bill.pdf"' % slugify(event.event_name)
+    if not event.reviewed:
+        resp['Content-Disposition'] = 'inline; filename="%s-bill.pdf"' % slugify(event.event_name)
+    else:
+        resp['Content-Disposition'] = 'inline; filename="%s-quote.pdf"' % slugify(event.event_name)
     return resp
 
 


### PR DESCRIPTION
Follows the same logic as the title inside the PDF: "bill" once an event is reviewed, otherwise "quote".

Closes #618.