### PR TITLE
Fix `Add Row` to work for autocomplete fields 

### DIFF
--- a/site_tmpl/js_formset_add_row.tmpl
+++ b/site_tmpl/js_formset_add_row.tmpl
@@ -24,8 +24,9 @@
     }
     $('#add_form').click(function() {
         add_form();
+        $(window).trigger('init-autocomplete');
     });
-    $('.table').keypress(function(e) {
-        if (e.which == 13) { add_form();}
-    });
+    //$('.table').keypress(function(e) {
+    //    if (e.which == 13) { add_form();}
+    //});
 </script>


### PR DESCRIPTION
Reinitializes autocomplete after adding a new row. Also removed new form on `enter` or `return` keypress as it was causing some unintended behavior with multi-line text fields. Closes #633.