### PR TITLE
399 reduce redundancy in row based forms

### DIFF
--- a/events/forms.py
+++ b/events/forms.py
@@ -1312,6 +1312,8 @@ class CCIForm(forms.ModelForm):
         if isinstance(event, Event2019):
             self.fields['category'].queryset = Category.objects.filter(
                 pk__in=event.serviceinstance_set.values_list('service__category', flat=True))
+            if len(self.fields['category'].queryset) == 1:
+                self.fields['category'].initial = self.fields['category'].queryset.first()
         self.fields['setup_start'].initial = self.fields['setup_start'].prepare_value(
             self.event.datetime_setup_complete.replace(second=0, microsecond=0)
         )

--- a/events/forms.py
+++ b/events/forms.py
@@ -1238,6 +1238,8 @@ class MKHoursForm(forms.ModelForm):
         if isinstance(event, Event2019):
             self.fields['category'].queryset = Category.objects.filter(
                 pk__in=event.serviceinstance_set.values_list('service__category', flat=True))
+            if len(self.fields['category'].queryset) == 1:
+                self.fields['category'].initial = self.fields['category'].queryset.first()
 
     def clean(self):
         super(MKHoursForm, self).clean()
@@ -1788,6 +1790,8 @@ class CrewCheckinForm(forms.Form):
                 options.append((event.pk, " %s" % event.event_name))
 
         self.fields['event'] = forms.ChoiceField(choices=options, label="Select Event", widget=forms.RadioSelect)
+        if len(options) == 1:
+            self.fields['event'].initial = options[0][0]
 
 
 class CrewCheckoutForm(forms.Form):
@@ -1847,6 +1851,8 @@ class CheckoutHoursForm(forms.Form):
                                                                          min_value=0)
             hour_set.fields.append(Column('hours_%s' % category.name, css_class="mx-2"))
         hour_set.fields.append(Column('total', css_class="mx-2"))
+        if len(categories) == 1:
+            self.fields['hours_%s' % categories[0].name].initial = self.total_hrs
 
     def clean(self):
         cleaned_data = super(CheckoutHoursForm, self).clean()

--- a/events/views/flow.py
+++ b/events/views/flow.py
@@ -1,12 +1,12 @@
 import math
-from datetime import timedelta
+from datetime import datetime, timedelta
 from decimal import Decimal
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required, permission_required
 from django.core.exceptions import PermissionDenied, ValidationError
-from django.db.models import Avg, Count
+from django.db.models import Avg, Count, Q
 from django.forms.models import inlineformset_factory
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
@@ -463,6 +463,7 @@ def hours_prefill_self(request, id):
     if event.hours.filter(user=request.user).exists():
         messages.add_message(request, messages.ERROR, 'You already have hours for this event.')
         return HttpResponseRedirect(reverse('events:detail', args=(event.id,)))
+        # return HttpResponseRedirect(reverse('events:crew-checkout'))
     if timezone.now() < min(event.ccinstances.values_list('setup_start', flat=True)):
         messages.add_message(request, messages.ERROR, 'You cannot use this feature until the event setup has started.')
         return HttpResponseRedirect(reverse('events:detail', args=(event.id,)))
@@ -1084,6 +1085,10 @@ def viewevent(request, id):
                 session.save()
 
     context['apps'] = apps
+
+    context['can_selfcrew'] = request.user.is_lnl & BaseEvent.objects.filter(
+        Q(closed=False) & Q(cancelled=False), id=event.id, ccinstances__setup_start__lte=timezone.now(),
+        datetime_end__gte=(timezone.now() - timedelta(hours=3))).exists()
 
     return render(request, 'uglydetail.html', context)
 

--- a/events/views/flow.py
+++ b/events/views/flow.py
@@ -461,7 +461,7 @@ def hours_prefill_self(request, id):
     if not event.ccinstances.exists():
         raise PermissionDenied
     if event.hours.filter(user=request.user).exists():
-        messages.add_message(request, messages.ERROR, 'You already have hours for this event.')
+        messages.add_message(request, messages.ERROR, 'You are already checked in to this event.')
         return HttpResponseRedirect(reverse('events:detail', args=(event.id,)))
         # return HttpResponseRedirect(reverse('events:crew-checkout'))
     if timezone.now() < min(event.ccinstances.values_list('setup_start', flat=True)):
@@ -504,7 +504,7 @@ def checkin(request):
 
     if request.user.event_records.filter(active=True).exists():
         context['page'] = {"title": "You are already checked into an event",
-                           "body": "<a href='" + reverse("events:crew-tracker") + "' class='btn btn-primary'>Back</a>"}
+                           "body": "<a href='" + reverse("events:crew-checkout") + "' class='btn btn-primary'>Go to Crew Checkout</a>"}
         return render(request, 'static_page.html', context)
 
     if request.method == 'POST':

--- a/site_tmpl/admin.html
+++ b/site_tmpl/admin.html
@@ -18,16 +18,13 @@
                 {% if selfcrew_events.exists %}
                     <div class="visible-xs panel panel-default">
                         <div class="panel-heading">
-                            <h3 class="panel-title">Mark yourself as crew for an ongoing event</h3>
+                            <h3 class="panel-title">Select the event name to mark yourself as crew</h3>
                         </div>
                         <div class="panel-body">
-                            <a class="btn btn-primary" href="{% url 'events:crew-checkin' %}">Check in</a>
-                            <a class="btn btn-primary" href="{% url 'events:crew-checkout' %}">Check out</a>
-                            {% comment %}
                             {% for event in selfcrew_events %}
                                 <a class="btn btn-default" href="{% url 'events:selfcrew' event.id %}">{{ event.event_name }}</a>
                             {% endfor %}
-                            {% endcomment %}
+                            <a class="btn btn-warning" href="{% url 'events:crew-checkout' %}">Crew Check Out</a>
                         </div>
                     </div>
                 {% endif %}
@@ -49,6 +46,10 @@
                         {% endpermission %}
                         {% if request.user.is_superuser %}
                             <a class="btn btn-danger" href="../admin">Admin</a>
+                        {% endif %}
+                        {% if selfcrew_events.exists %}
+                            <a class="hidden-xs btn btn-warning" href="{% url 'events:crew-checkin' %}">Crew Check In</a>
+                            <a class="hidden-xs btn btn-warning" href="{% url 'events:crew-checkout' %}">Crew Check Out</a>
                         {% endif %}
                     </div>
                 </div>

--- a/site_tmpl/admin.html
+++ b/site_tmpl/admin.html
@@ -18,7 +18,7 @@
                 {% if selfcrew_events.exists %}
                     <div class="visible-xs panel panel-default">
                         <div class="panel-heading">
-                            <h3 class="panel-title">Select the event name to mark yourself as crew</h3>
+                            <h3 class="panel-title">Select an event to check in</h3>
                         </div>
                         <div class="panel-body">
                             {% for event in selfcrew_events %}

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -18,9 +18,9 @@
             <h3>Status: <b>{{ event.status }}</b></h3>
 
             <div class="btn-group">
-                {% if can_selfcrew %}
+                <!--{% if can_selfcrew %}
                     <a class="btn btn-warning btn-lg" href="{% url "events:crew-tracker" %}">Crew Check In/Out</a>
-                {% endif %}
+                {% endif %}-->
                 {% permission request.user has 'events.view_event_reports' of event %}
                     <a class="btn btn-info btn-lg" href="{% url "events:pdf" event.id %}">PDF</a>
                 {% endpermission %}

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -18,6 +18,9 @@
             <h3>Status: <b>{{ event.status }}</b></h3>
 
             <div class="btn-group">
+                {% if can_selfcrew %}
+                    <a class="btn btn-warning btn-lg" href="{% url "events:crew-tracker" %}">Crew Check In/Out</a>
+                {% endif %}
                 {% permission request.user has 'events.view_event_reports' of event %}
                     <a class="btn btn-info btn-lg" href="{% url "events:pdf" event.id %}">PDF</a>
                 {% endpermission %}


### PR DESCRIPTION
In crew checkin/out, select single radio buttons by default and autofill when only one option is accepted. In crew hours and CC assignments for events with one category of services, the category is selected by default.