### PR TITLE
Skip RT tests when RT is offline

### DIFF
--- a/rt/tests.py
+++ b/rt/tests.py
@@ -1,3 +1,5 @@
+from unittest import skipIf
+import requests
 from data.tests.util import ViewTestCase
 from django.shortcuts import reverse
 from django.conf import settings
@@ -8,6 +10,7 @@ from accounts.models import UserPreferences
 
 
 class RTAPITests(ViewTestCase):
+    @skipIf(requests.head('https://lnl-rt.wpi.edu/rt/REST/2.0/ticket').status_code != 200, "RT is not reachable")
     def test_ticket_form(self):
         # Check that form loads ok
         self.assertOk(self.client.get(reverse("support:new-ticket")))


### PR DESCRIPTION
Some tests currently fail if RT is offline, so this PR skips tests that require RT to be online if RT is unavailable.