### PR TITLE
fix quorum calculation in secretary dashboard

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -265,7 +265,7 @@ class AccountsTestCase(ViewTestCase):
         self.user.user_permissions.add(permission)
 
         self.assertOk(self.client.get(reverse("accounts:secretary_dashboard")))
-        
+
         # test that with 3 active users, quorum is 2
         for _ in range(3):
             active_user = UserFactory.create()

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -265,6 +265,23 @@ class AccountsTestCase(ViewTestCase):
         self.user.user_permissions.add(permission)
 
         self.assertOk(self.client.get(reverse("accounts:secretary_dashboard")))
+        
+        # test that with 3 active users, quorum is 2
+        for _ in range(3):
+            active_user = UserFactory.create()
+            self.active.user_set.add(active_user)
+        self.assertContains(self.client.get(reverse("accounts:secretary_dashboard")), "<td>Quorum</td><td>2</td>", html=True)
+
+        # test that with 4 active users, quorum is 3
+        active_user = UserFactory.create()
+        self.active.user_set.add(active_user)
+        self.assertContains(self.client.get(reverse("accounts:secretary_dashboard")), "<td>Quorum</td><td>3</td>", html=True)
+
+        # test that with 5 active users, quorum is 3
+        active_user = UserFactory.create()
+        self.active.user_set.add(active_user)
+        self.assertContains(self.client.get(reverse("accounts:secretary_dashboard")), "<td>Quorum</td><td>3</td>", html=True)
+
 
     def test_shame(self):
         self.setup()

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -319,7 +319,7 @@ def secretary_dashboard(request):
 
     context = {}
     num_active = get_user_model().objects.filter(groups__name='Active').count()
-    simple_majority = int(math.ceil(num_active / 2.0)) + 1
+    simple_majority = int(math.floor(num_active / 2.0)) + 1
     two_thirds_majority = int(math.ceil(num_active * 2 / 3.0))
     members_to_activate = get_user_model().objects.filter(groups__name='Associate') \
         .annotate(hours_count=Count(Case(When(hours__event__datetime_start__gte=semester_ago, then=F('hours'))),


### PR DESCRIPTION
fixes #816 

The original version had `ceil(num_active / 2)`, which will round up correctly with odd numbers of members, but with an even number of members will calculate half instead of half plus one.

The second version had `ceil(num_active / 2) + 1`, which will correctly add one when there's an even number of members, but double up because `ceil` already rounds up with an odd number.

This third version replaces the `ceil` with a `floor` to always calculate the correct result.