### PR TITLE
add the ability to duplicate events

### DIFF
--- a/events/urls/events.py
+++ b/events/urls/events.py
@@ -62,6 +62,7 @@ urlpatterns = [
     # re_path(r'^db/events/mk/$', 'events.views.mkedrm.eventnew', name="event-new"),
     re_path(r'^mk/$', mkedrm_views.eventnew, name="new"),
     re_path(r'^edit/(?P<id>[0-9a-f]+)/$', mkedrm_views.eventnew, name="edit"),
+    re_path(r'^duplicate/(?P<id>[0-9a-f]+)/$', mkedrm_views.duplicate_event, name="duplicate"),
     re_path(r'^approve/(?P<id>[0-9a-f]+)/$', flow_views.approval, name="approve"),
     re_path(r'^deny/(?P<id>[0-9a-f]+)/$', flow_views.denial, name="deny"),
     re_path(r'^review/(?P<id>[0-9a-f]+)/$', flow_views.review, name="review"),

--- a/site_tmpl/uglydetail.html
+++ b/site_tmpl/uglydetail.html
@@ -30,6 +30,10 @@
                             <a class="btn btn-primary btn-lg" target="_blank" href="https://25live.collegenet.com/pro/wpi#!/home/event/{{ event.event_id }}/details">25Live</a>
                         </tr>
                 {% endif %}
+                {% permission request.user has 'events.add_raw_event' %}
+                    <a class="btn btn-success btn-lg"
+                       href="{% url "events:duplicate" event.id %}">Duplicate</a>
+                {% endpermission %}
                 {% if event.closed %}
                     {% permission request.user has 'events.reopen_event' of event %}
                         <a class="btn btn-default btn-lg" href="#reopenModal" role="button"


### PR DESCRIPTION
Prefills a new event form with data copied from an existing event.

This method does require specifying exactly which fields should be prefilled, so lmk if you have any opinions on which fields should be copied.



closes #864  
@MistHelix is this what you were looking for?