### PR TITLE
Show missing CC reports

### DIFF
--- a/events/views/my.py
+++ b/events/views/my.py
@@ -90,6 +90,7 @@ def myevents(request):
     """ Lists events that a user has CC'd or been involved with """
     context = {'user': request.user, 'now': datetime.datetime.now(timezone.get_current_timezone()),
                'ccinstances': request.user.ccinstances.select_related('event__location').all(),
+               'did_cc_report': request.user.ccinstances.filter(event__ccreport__crew_chief=request.user.pk).all(),
                'orgs': request.user.all_orgs.prefetch_related('events__location'),
                'submitted_events': request.user.submitter.select_related('location').all(),
                'hours': request.user.hours.select_related('event__location').all()}

--- a/site_tmpl/myevents.html
+++ b/site_tmpl/myevents.html
@@ -27,8 +27,11 @@
                             <a class="btn btn-default" href="{% url 'events:pdf' instance.event.id %}">Workorder
                                 PDF </a>
                             {% if instance.event.approved %} 
-                                <a class="btn btn-primary" href="{% url "my:report" instance.event.id %}">CC
-                                    Report</a>
+                                {% if instance in did_cc_report %}
+                                    <a class="btn btn-success" href="{% url "my:report" instance.event.id %}">CC Report</a>
+                                {% else %}
+                                    <a class="btn btn-primary" href="{% url "my:report" instance.event.id %}">CC Report</a>
+                                {% endif %}
                                 <a class="btn btn-primary" href="{% url "my:hours-list" instance.event.id %}">Crew Hours</a>
                             {% endif %}
                             <a class="btn btn-success" target="_blank" href="https://wpi0.sharepoint.com/sites/gr-lnl/Event%20Photos/Forms/Thumbnails.aspx?view=7&q={{ instance.event.event_name|urlencode }}">Photos</a>


### PR DESCRIPTION
Changes the color of the cc-report button on the my-events page to reflect whether the report already exists or is still missing.

closes #933 