### PR TITLE
change form sender to match "save changes" submitting the form

### DIFF
--- a/meetings/forms.py
+++ b/meetings/forms.py
@@ -154,7 +154,7 @@ class AnnounceSendForm(forms.ModelForm):
             'email_to',
             Field('events', css_class="col-md-6", size="15"),
             FormActions(
-                Submit('save', 'Save Changes'),
+                Submit('save', 'Submit'),
             )
         )
 


### PR DESCRIPTION
The secretary view currently has "save changes" as the way to submit the email meeting notice reminder. This change makes it clear that that button submits the email and will immediately send. 